### PR TITLE
SetModelScale input & clarify modelscale field description

### DIFF
--- a/fgd/bases/BaseEntityAnimating.fgd
+++ b/fgd/bases/BaseEntityAnimating.fgd
@@ -42,7 +42,7 @@
 	texframeindex(integer) : "Texture Frame" : : "The frame number for any animated textures on this entity."
 	hitboxset(string) : "Hitbox Set" : : "Sets the $hboxset to use for collision testing."
 	
-	modelscale(float) : "Model Scale" : : "A multiplier for the size of the model. Negative values are accepted. Does not alter the physics collisions in most cases, however. Negative values can crash the game!"
+	modelscale(float) : "Model Scale" : : "A multiplier for the size of the model."
 	
 	linedivider_animbase[!engine](string) readonly : "----------------------------------------------------------------------------------------------------------" : ""
 
@@ -90,6 +90,8 @@
 	input EnableReceivingFlashlight(void) : "This object may recieve light or shadows from projected textures (flashlights)."
 	
 	input AlternativeSorting(boolean) : "Used to attempt to fix sorting problems when rendering. True activates, false deactivates"
+
+	input SetModelScale(vector) : "Sets the scale of the model. Secondary parameter (space delimited) sets the duration of time to scale the model."
 
 	// Outputs
 	output OnIgnite(void) : "Fired when this object catches fire."

--- a/fgd/bases/BaseEntityPhysics.fgd
+++ b/fgd/bases/BaseEntityPhysics.fgd
@@ -28,7 +28,7 @@
 	shadowcastdist(integer) : "Shadow Cast Distance" : : "Sets how far the entity casts dynamic shadows, in units. 0 means default distance from the shadow_control entity."
 	disableshadows(boolean) : "Disable Shadows?" : 0 : "Prevent the entity from creating cheap render-to-texture/dynamic shadows."
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
-	modelscale(float) : "Model Scale" : : "A multiplier for the size of the model. Negative values are accepted. Does not alter the physics collisions in most cases, however. Negative values can crash the game!"
+	modelscale(float) : "Model Scale" : : "A multiplier for the size of the model."
 	
 	linedivider_phys[!engine](string) readonly : "----------------------------------------------------------------------------------------------------------" : ""
 
@@ -49,6 +49,8 @@
 	input EnableShadow(void) : "Prevents the entity from drawing a render target (dynamic) shadow."
 	
 	input AlternativeSorting(boolean) : "Used to attempt to fix sorting problems when rendering. True activates, false deactivates"
+	
+	input SetModelScale(vector) : "Sets the scale of the model. Secondary parameter (space delimited) sets the duration of time to scale the model."
 
 	// Outputs
 	output OnIgnite(void) : "Fired when this object catches fire."


### PR DESCRIPTION
Adding back the `SetModelScale` input as it is now supported.

Hiding the secret third parameter as nonhierarchical scaling isnt correctly implemented yet.