### PR TITLE
Stop culling bases that provide additional bases

### DIFF
--- a/unify_fgd.py
+++ b/unify_fgd.py
@@ -765,13 +765,13 @@ def action_export(
 
     print('Culling unused bases...')
     used_bases = set()  # type: Set[EntityDef]
-    # We only want to keep bases that provide keyvalues. We've merged the
-    # helpers in.
+    # We only want to keep bases that provide keyvalues or additional bases.
+    # We've merged the helpers in.
     for ent in fgd.entities.values():
         if ent.type is not EntityTypes.BASE:
             for base in ent.iter_bases():
                 if base.type is EntityTypes.BASE and (
-                    base.keyvalues or base.inputs or base.outputs
+                    base.keyvalues or base.inputs or base.outputs or base.bases
                 ):
                     used_bases.add(base)
 


### PR DESCRIPTION
The unify script currently culls all bases except those that provide keyvalues, inputs, or outputs. It does not take additional bases into account though, meaning that bases with additional bases will be culled if they have no keyvalues, inputs, and outputs.

This causes some hierarchies to be dismantled when they shouldnt be. 
For instance, `item_ammo_357` has the `ItemAmmo` base, which has the `Item` base. However, because `ItemAmmo` does not have any keyvalues, inputs, nor outputs, it is incorrectly culled. This leaves `item_ammo_357` with no kvs/inputs/outputs at all.

This does not effect any entities P2CE uses except those that have the base `ItemAmmo`, which are all HL2 entities.
As for momentum, this fixes the issue of `MomentumTrigger` base being culled and changes nothing else.
Done by comparing which bases are culled with & without the change.