### PR TITLE
Remove PROP_SCALING switch/tag

### DIFF
--- a/fgd/point/prop/prop_static.fgd
+++ b/fgd/point/prop/prop_static.fgd
@@ -33,7 +33,7 @@
 	renderamt(integer) : "Alpha" : 255 : "Alpha of the fade, where 0 = fully transparent and 255 = fully opaque."
 	rendercolor(color255) : "Color (R G B)" : "255 255 255"
 
-	uniformscale[PROP_SCALING](float) : "Uniform Scale Override" : 1 : "Resize the static prop."
+	uniformscale(float) : "Uniform Scale Override" : 1 : "Resize the static prop."
 
 
 	solid[engine](integer) : "Collisions" : 6

--- a/unify_fgd.py
+++ b/unify_fgd.py
@@ -43,8 +43,8 @@ GAME_NAME = dict(GAMES)
 # Specific features that are backported to various games.
 
 FEATURES: Dict[str, Set[str]] = {
-    'P2CE': {'HL2_ENTITIES', 'INSTANCING', 'INST_IO', 'PROP_SCALING', 'VSCRIPT', 'PROPCOMBINE'},
-    'MOMENTUM': {'INSTANCING', 'INST_IO', 'PROP_SCALING', 'PROPCOMBINE'},
+    'P2CE': {'HL2_ENTITIES', 'INSTANCING', 'INST_IO', 'VSCRIPT', 'PROPCOMBINE'},
+    'MOMENTUM': {'INSTANCING', 'INST_IO', 'PROPCOMBINE'},
 }
 
 ALL_FEATURES = {


### PR DESCRIPTION
All Chaos games have prop scaling; no need for this tag.