### PR TITLE
Upstream's baseentity for engine dumps

### DIFF
--- a/fgd/base_entity.fgd
+++ b/fgd/base_entity.fgd
@@ -1,0 +1,200 @@
+// For use in the engine dump, the keyvalues available on CBaseEntity and therefore on all entities.
+// This way they don't need to be re-declared on every ent.
+
+@PointClass appliesto(engine) = _CBaseEntity_
+	[
+	classname(string) : "Classname" : : "The class of the entity, and is changed."
+	origin(origin) : "Position" : "0 0 0"
+	angles(angle) : "Pitch Yaw Roll (X Y Z)" : "0 0 0"
+
+	targetname(target_source) : "Name"
+	hammerid(integer) : "Hammer ID"
+	target(target_destination) : "Target" 
+	spawnflags(flags) = []
+
+
+	vscripts[VSCRIPT](scriptlist) : "Entity Scripts"
+	thinkfunction[VSCRIPT](string) : "Script think function"
+	nextthink(integer) : "Next Think"
+
+	globalname(string) : "Global Entity Name"
+
+	vscript_init_code[+VSCRIPT, +srctools](string) : "Init Code"
+	vscript_init_code2[+VSCRIPT, +srctools](string) : "Init Code"
+	vscript_init_code3[+VSCRIPT, +srctools](string) : "Init Code"
+	vscript_init_code4[+VSCRIPT, +srctools](string) : "Init Code"
+	vscript_init_code5[+VSCRIPT, +srctools](string) : "Init Code"
+
+	mincpulevel(integer) : "Min CPU Level" : 0
+	maxcpulevel(integer) : "Max CPU Level" : 0
+	mingpulevel(integer) : "Min GPU Level" : 0
+	maxgpulevel(integer) : "Max GPU Level" : 0
+
+	parentname(target_destination) : "Parent"
+	parent_attachment_point[srctools](string) : "Attachment Point"
+
+	teamnumber(integer) : "Team number" : : "Team number this entity is on."
+	pendingteamnumber(integer) : "Pending Team Number" : : "Team numer this entity will be on at the beginning of the next round."
+
+	responseContext(string) : "Response Context" : ""
+	addon(string) : "AI Addon" : : "Broken ASW feature."
+	
+	health(integer) : "Health"
+	max_health(integer) : "Max Health"
+	is_autoaim_target(boolean) : "Is Autoaim Target" : 0
+	damagefilter(filterclass) : "Damage Filter"
+	nodamageforces(boolean) : "No damage forces"
+
+	renderfx(integer) : "Render FX" : 0
+	rendermode(integer) : "Render Mode" : 0
+	renderamt(integer) : "Render Alpha" : 255
+	effects(integer) : "Effects" : 0
+	rendercolor(color255) : "Render Color" : "255 255 255"
+	modelindex(integer) : "Model Index" : 0 : "Internal model index, shouldn't be used."
+	model(studio) : "Model" : "" : "Model/sprite name, or brush index."
+	shadowcastdist(integer) : "Shadow Cast Distance" : 0
+	texframeindex(integer) : "Texture Frame" : 0
+	drawinfastreflection(boolean) : "Draw In Fast Reflections"
+	disableshadows(boolean) : "Disable Shadows"
+	disablereceiveshadows(boolean) : "Disable Recieving Shadows"
+	disableflashlight(boolean) : "Disable Projected Texture Shadows"
+	disableshadowdepth(boolean) : "Disable Shadow Depth"
+	shadowdepthnocache(integer) : "Cache in Shadow Depth"
+
+	viewhideflags(integer) : "View ID nodraw" : 0 : "This keyvalue can control whether an entity should only draw on things like monitors or mirrors, " +
+		"or the opposite. The code for this is { m_iViewHideFlags & (1 << CurrentViewID()) } and supports any combination of view IDs."
+	fadescale(float) : "Fade Scale" : 1 : "If you specify a fade in the worldspawn, then the engine will forcibly fade out props even if fademindist/fademaxdist isn't specified." +
+		"This scale factor gives you some control over the fade. " +
+		"Using 0 here turns off the forcible fades. " +
+		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
+		"and greater than 1 cause it to fade out at closer distances."
+
+	movetype(integer) : "Movement Type" : 0
+	collisiongroup(integer) : "Collision Group" : 0
+	speed(float) : "Speed" : 0
+	basevelocity(vector) : "Base Velocity"
+	velocity(vector) : "Velocity"
+	avelocity(vector) : "Angular Velocity"
+	waterlevel(integer) : "Water Level": 0 : "Depth of water the entity is in."
+	gravity(float) : "Gravity"
+	friction(float) : "Friction"
+	ltime(float) : "Local Time"
+	view_ofs(vector) : "View Offset"
+	lagCompensate(boolean) : "Enable lag compensation"
+
+
+	// Inputs
+	input Kill(void) : "Removes this entity from the world."
+	input KillHierarchy(void) : "Removes this entity and all its children from the world."
+
+	input SetParent(target_destination) : "Changes the entity's parent in the movement hierarchy."
+	input SetParentAttachment(string) : "Change this entity to attach to a specific attachment point on its parent. Entities must be parented before being sent this input. The parameter passed in should be the name of the attachment."
+	input SetParentAttachmentMaintainOffset(string) : "Change this entity to attach to a specific attachment point on it's parent. Entities must be parented before being sent this input. The parameter passed in should be the name of the attachment. The entity will maintain it's position relative to the parent at the time it is attached."
+	input ClearParent(void) : "Removes this entity from the the movement hierarchy, leaving it free to move independently."
+	input SetLocalAngles(vector) : "Sets the rotation of the entity relative to the parent's rotation."
+	input SetLocalOrigin(vector) : "Sets the position of the entity relative to its parent if one exists. Otherwise relative to the world."
+	input SetAbsAngles(vector) : "Set this entity's angles, always relative to the world origin."
+
+	input AddOutput(string) : "Adds an entity I/O connection to this entity or changes keyvalues dynamically. Format:" +
+		"\n'<output name> <targetname>:<inputname>:" + 
+		"<parameter>:<delay>:<max times to fire (-1 == infinite, 1 = only once)>'\n" +
+		"or 'keyvalue newval'. Very dangerous, use with care."
+	input FireUser1(void) : "Causes this entity's OnUser1 output to be fired."
+	input FireUser2(void) : "Causes this entity's OnUser2 output to be fired."
+	input FireUser3(void) : "Causes this entity's OnUser3 output to be fired."
+	input FireUser4(void) : "Causes this entity's OnUser4 output to be fired."
+	input Use(void) : "Same as a player invoking +use; may not do anything. Can also be invoked by creating an output that does not specify an input."
+	input DispatchEffect(string) : "Dispatch an effect from the entity's origin. See https://developer.valvesoftware.com/wiki/List_of_Client_Effects"
+
+	input RunScriptFile[VSCRIPT](string) : "Execute a game script file from disk."
+	input RunScriptCode[+VSCRIPT, -srctools](script) : "Execute a string of script source code."
+	input RunScriptCode[+VSCRIPT, +srctools](script) : "Execute a string of script source code. Backtick ( ` ) characters will be converted to quotes in-game for strings."
+	input CallScriptFunction[VSCRIPT](string) : "Execute the given function name."
+
+	input Alpha(integer) : "Set the entity's alpha (0 - 255)."
+	input Color(color255) : "Set the entity's color (R G B)."
+	input SetRenderMode(integer) : "Sets this entity's render mode."
+	input SetRenderFX(integer) : "Sets this entity's render FX."
+	input SetViewHideFlags(integer) : "Sets this entity's view ID nodraw flags (takes raw flag combination)."
+	input AddEffects(integer) : "Adds an entity effect."
+	input RemoveEffects(integer) : "Removes an entity effect."
+	input AddEFlags(integer) : "Adds an entity flag. NOTE: Entity flags are not the spawn flags you see in Hammer. Use AddSpawnFlags to add spawnflags."
+	input RemoveEFlags(integer) : "Removes an entity flag. NOTE: Entity flags are not the spawn flags you see in Hammer. Use RemoveSpawnFlags to remove spawnflags."
+
+	input AlternativeSorting(boolean) : "Set the translucency sorting algorithm."
+	input DispatchResponse(string) : "Dispatch an NPC response"
+	input SetTeam(integer): "Set the team."
+
+	input SetDamageFilter(target_destination) : "Set Damage Filter"
+	input EnableDamageForces(void)
+	input DisableDamageForces(void)
+
+	input AddContext(string) : "Set the given context values, given a  string in the format 'key1:value1,key2:value2,...'."
+	input RemoveContext(string) : "Remove the specified context value."
+	input ClearContext(void) : "Remove all the context."
+
+	input DisableShadow(void) : "Turn off the basic shadow underneath entities."
+	input EnableShadow(void) : "Turn on the basic shadow underneath entities."
+
+	input DisableDraw(void) : "Disable rendering this entity."
+	input EnableDraw(void) : "Enable rendering this entity."
+
+	input DisableReceivingFlashlight(void) : "Disable projected texture shadows on this entity."
+	input EnableReceivingFlashlight(void) : "Enable projected texture shadows on this entity."
+
+	input DisableDrawInFastReflection(void) : "Disable drawing in the world impostor pass and water."
+	input EnableDrawInFastReflection(void) : "Enable drawing in the world impostor pass and water."
+
+	input RemovePaint[P2CE](void) : "Remove paint from a brush."
+
+	input PassUser1(string) : "Causes this entity's OutUser1 output to be fired, passing along the parameter unchanged."
+	input PassUser2(string) : "Causes this entity's OutUser2 output to be fired, passing along the parameter unchanged."
+	input PassUser3(string) : "Causes this entity's OutUser3 output to be fired, passing along the parameter unchanged."
+	input PassUser4(string) : "Causes this entity's OutUser4 output to be fired, passing along the parameter unchanged."
+
+	input FireRandomUser(void) : "Fires OnUser1, OnUser2, OnUser3, or OnUser4 with a 25% chance of each."
+	input PassRandomUser(string) : "Fires OutUser1, OutUser2, OutUser3, or OutUser4 with a 25% chance of each. The parameter is passed along unchanged."
+	
+	input FireOutput(string) : "Fires the named output on this entity. Format: '<output name>:<activator>:<caller>:<parameter>:<delay>' (OnDeath:hl3cardgame:gaben). Everything beyond the output name is optional."
+	input RemoveOutput(string) : "Removes all instances of the named output on this entity. Wildcards are supported, meaning you could just pass '*' to wipe all outputs from this entity."
+	input AcceptInput(string) : "Fires the named input on this entity. Format: '<input name>:<parameter>:<activator>:<caller>:<output ID>' (SetTarget:cheese). Everything beyond the input name is optional. Mind the fact this is arranged differently from FireOutput, having the parameter right after the input name."
+	input CancelPending(void) : "Cancels any events fired by this entity that are currently pending in the I/O event queue."
+	
+	input FreeChildren(void) : "Unparents all direct children of this entity."
+	input SetLocalVelocity(vector) : "Sets this entity's current velocity."
+	input SetLocalAngularVelocity(vector) : "Sets this entity's current angular velocity."
+	
+	input AddSpawnFlags(integer) : "Adds spawnflag(s) to this entity. Many spawnflags have their respective numbers suffixed in this FGD."
+	input RemoveSpawnFlags(integer) : "Removes spawnflag(s) to this entity. Many spawnflags have their respective numbers suffixed in this FGD."
+
+	input AddSolidFlags(integer) : "Adds solid flags to this entity."
+	input RemoveSolidFlags(integer) : "Removes solid flags from this entity."
+
+	input ChangeVariable(string) : "Similar to AddOutput, except it changes an internal variable similar to logic_datadesc_accessor instead. Very dangerous, use with care."
+	
+	input SetHealth(integer) : "Sets this entity's health."
+	input AddHealth(integer) : "Adds to this entity's health."
+	input RemoveHealth(integer) : "Removes from this entity's health."
+	
+	input SetMaxHealth(integer) : "Sets this entity's max health."
+	
+	input SetEntityName(target_destination) : "Sets this entity's name that other entities should refer to it by."
+	input SetTarget(target_destination) : "Sets this entity's target. This is specific to certain entities, particularly logic entities that involve a target."
+	input SetOwnerEntity(target_destination) : "Sets this entity's owner entity. This has nothing to do with parenting and has more to do with collision and kill credits."
+	
+	input SetThinkNull(void) : "Sets this entity's general think function to null. Behavior varies from entity to entity.."
+	
+	input Touch(target_destination) : "Simulates this entity touching the specified entity."
+
+
+	// Outputs
+	output OnUser1(void) : "Fired in response to FireUser1 input."
+	output OnUser2(void) : "Fired in response to FireUser2 input."
+	output OnUser3(void) : "Fired in response to FireUser3 input."
+	output OnUser4(void) : "Fired in response to FireUser4 input."
+
+	output OutUser1(string) : "Fires in response to PassUser1 input, with the parameter passed through unchanged."
+	output OutUser2(string) : "Fires in response to PassUser2 input, with the parameter passed through unchanged."
+	output OutUser3(string) : "Fires in response to PassUser3 input, with the parameter passed through unchanged."
+	output OutUser4(string) : "Fires in response to PassUser4 input, with the parameter passed through unchanged."
+	]

--- a/fgd/bases/BaseEntityAnimating.fgd
+++ b/fgd/bases/BaseEntityAnimating.fgd
@@ -51,7 +51,11 @@
 	
 	fademindist(float) : "Start Fade Distance/Pixels" : : "Distance at which the entity starts fading. If <0, the entity will disappear instantly when end fade is hit. The value will scale appropriately if the entity is in a 3D Skybox."
 	fademaxdist(float) : "End Fade Distance/Pixels" : : "Distance at which the entity ends fading. If <0, the entity won't disappear at all. The value will scale appropriately if the entity is in a 3D Skybox."
-	fadescale(float) : "Fade Scale" : : "If specified in the worldspawn, or if the engine is running below DirectX 8, entities will fade out even if the fade distances above aren't specified. This value gives more control over when this happens: numbers smaller than 1 cause the entity to fade out at further distances, and greater than 1 cause it to fade out at closer distances. Using 0 turns off the forced fade altogether."	
+	fadescale(float) : "Fade Scale" : 1 : "If you specify a fade in the worldspawn, then the engine will forcibly fade out props even if fademindist/fademaxdist isn't specified." +
+		"This scale factor gives you some control over the fade. " +
+		"Using 0 here turns off the forcible fades. " +
+		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
+		"and greater than 1 cause it to fade out at closer distances."
 	
 	shadowcastdist(integer) : "Shadow Cast Distance" : : "Sets how far the entity casts dynamic shadows, in units. 0 means default distance from the shadow_control entity."
 	disableshadows(boolean) : "Disable Shadows?" : 0 : "Prevent the entity from creating cheap render-to-texture/dynamic shadows."

--- a/fgd/bases/BaseEntityPhysics.fgd
+++ b/fgd/bases/BaseEntityPhysics.fgd
@@ -24,7 +24,12 @@
 	
 	fademindist(float) : "Start Fade Distance/Pixels" : : "Distance at which the entity starts fading. If <0, the entity will disappear instantly when end fade is hit. The value will scale appropriately if the entity is in a 3D Skybox."
 	fademaxdist(float) : "End Fade Distance/Pixels" : : "Distance at which the entity ends fading. If <0, the entity won't disappear at all. The value will scale appropriately if the entity is in a 3D Skybox."
-	fadescale(float) : "Fade Scale" : : "If specified in the worldspawn, or if the engine is running below DirectX 8, entities will fade out even if the fade distances above aren't specified. This value gives more control over when this happens: numbers smaller than 1 cause the entity to fade out at further distances, and greater than 1 cause it to fade out at closer distances. Using 0 turns off the forced fade altogether."	
+	fadescale(float) : "Fade Scale" : 1 : "If you specify a fade in the worldspawn, then the engine will forcibly fade out props even if fademindist/fademaxdist isn't specified." +
+		"This scale factor gives you some control over the fade. " +
+		"Using 0 here turns off the forcible fades. " +
+		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
+		"and greater than 1 cause it to fade out at closer distances."
+
 	shadowcastdist(integer) : "Shadow Cast Distance" : : "Sets how far the entity casts dynamic shadows, in units. 0 means default distance from the shadow_control entity."
 	disableshadows(boolean) : "Disable Shadows?" : 0 : "Prevent the entity from creating cheap render-to-texture/dynamic shadows."
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."

--- a/fgd/bases/BaseFadeProp.fgd
+++ b/fgd/bases/BaseFadeProp.fgd
@@ -4,8 +4,10 @@
 = BaseFadeProp
 	[
 	fademindist(float) : "Start Fade Dist" : -1 : "Distance at which the prop starts to fade (<0 = use fademaxdist)."
-
 	fademaxdist(float) : "End Fade Dist" : 0 : "Max fade distance at which the prop is visible (0 = don't fade out)."
-	fadescale(float) : "Fade Scale" : 1 : "If you specify a fade in the worldspawn, or if the engine is running under low end/medium end/XBox360, then the engine will forc" + "ibly fade out props even if fademindist/fademaxdist isn't specified. This scale factor gives you some control over the fade. Usi" + "ng 0 here turns off the forcible fades. " +
-		"Numbers smaller than 1 cause the prop to fade out at further distances, and greater than 1 cause it to fade out at closer distances."
+	fadescale(float) : "Fade Scale" : 1 : "If you specify a fade in the worldspawn, then the engine will forcibly fade out props even if fademindist/fademaxdist isn't specified." +
+		"This scale factor gives you some control over the fade. " +
+		"Using 0 here turns off the forcible fades. " +
+		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
+		"and greater than 1 cause it to fade out at closer distances."
 	]

--- a/unify_fgd.py
+++ b/unify_fgd.py
@@ -748,6 +748,12 @@ def action_export(
                             elif base_value.type is value.type:
                                 del category[key]
                                 continue
+                            elif attr_name == 'keyvalues' and key == 'model':
+                                # This can be sprite or model.
+                                pass
+                            elif base_value.type is ValueTypes.FLOAT and value.type is ValueTypes.INT:
+                                # Just constraining it down to a whole number.
+                                pass
                             else:
                                 print(f'{ent.classname}.{key}: {value.type} != base {base_value.type}')
 

--- a/unify_fgd.py
+++ b/unify_fgd.py
@@ -145,7 +145,7 @@ def ent_path(ent: EntityDef) -> str:
 
 def load_database(dbase: Path, extra_loc: Path=None, fgd_vis: bool=False) -> Tuple[FGD, EntityDef]:
     """Load the entire database from disk. This returns the FGD, plus the CBaseEntity definition."""
-    print('Loading database:')
+    print(f'Loading database {dbase}:')
     fgd = FGD()
 
     fgd.map_size_min = -16384
@@ -940,9 +940,10 @@ def main(args: List[str]=None):
                     "between engine versions.",
 
     )
+    script_dir = Path(sys.argv[0]).parent
     parser.add_argument(
         "-d", "--database",
-        default="fgd/",
+        default=str(script_dir / "fgd/"),
         help="The folder to write the FGD files to or from."
     )
     parser.add_argument(

--- a/unify_fgd.py
+++ b/unify_fgd.py
@@ -649,6 +649,11 @@ def action_export(
                 helper for helper in ent.helpers
                 if not helper.IS_EXTENSION
             ]
+            # Force everything to inherit from CBaseEntity, since
+            # we're then removing any KVs that are present on that.
+            if ent.classname != BASE_ENTITY:
+                ent.bases = [base_entity_def]
+
             value: Union[IODef, KeyValues]
             category: Dict[str, Dict[FrozenSet[str], Union[IODef, KeyValues]]]
             base_cat: Dict[str, Dict[FrozenSet[str], Union[IODef, KeyValues]]]
@@ -745,7 +750,6 @@ def action_export(
                                 continue
                             else:
                                 print(f'{ent.classname}.{key}: {value.type} != base {base_value.type}')
-                        ent.bases = [base_entity_def]
 
                     # Blank this, it's not that useful.
                     value.desc = ''

--- a/unify_fgd.py
+++ b/unify_fgd.py
@@ -18,8 +18,7 @@ from typing import (
 
 from srctools.fgd import (
     FGD, validate_tags, match_tags,
-    EntityDef, EntityTypes,
-    HelperTypes, IODef,
+    EntityDef, EntityTypes, IODef,
     KeyValues, ValueTypes,
     HelperExtAppliesTo,
     HelperWorldText,
@@ -76,6 +75,9 @@ POLYFILLS = []  # type: List[Tuple[str, Callable[[FGD], None]]]
 # which Hammer displays as nothing. We can suffix visgroups with this to
 # have duplicates with the same name.
 VISGROUP_SUFFIX = '\x8D'
+
+# Special classname which has all the keyvalues and IO of CBaseEntity.
+BASE_ENTITY = '_CBaseEntity_'
 
 
 def format_all_tags() -> str:
@@ -141,8 +143,8 @@ def ent_path(ent: EntityDef) -> str:
     return '{}/{}.fgd'.format(folder, ent.classname)
 
 
-def load_database(dbase: Path, extra_loc: Path=None, fgd_vis: bool=False) -> FGD:
-    """Load the entire database from disk."""
+def load_database(dbase: Path, extra_loc: Path=None, fgd_vis: bool=False) -> Tuple[FGD, EntityDef]:
+    """Load the entire database from disk. This returns the FGD, plus the CBaseEntity definition."""
     print('Loading database:')
     fgd = FGD()
 
@@ -235,7 +237,12 @@ def load_database(dbase: Path, extra_loc: Path=None, fgd_vis: bool=False) -> FGD
             vis_count += 1
     print(f'\nVisgroup count: {vis_count}/{ent_count} ({vis_count*100/ent_count:.2f}%) done!')
 
-    return fgd
+    try:
+        base_entity_def = fgd.entities.pop(BASE_ENTITY.casefold())
+        base_entity_def.type = EntityTypes.BASE
+    except KeyError:
+        base_entity_def = EntityDef(EntityTypes.BASE)
+    return fgd, base_entity_def
 
 
 def load_visgroup_conf(fgd: FGD, dbase: Path) -> None:
@@ -308,8 +315,8 @@ def get_appliesto(ent: EntityDef) -> List[str]:
     arg_list = list(map(str.upper, applies_to))
     arg_list.sort()
     ent.helpers[:] = [
-        help for help in ent.helpers
-        if not isinstance(help, HelperExtAppliesTo)
+        helper for helper in ent.helpers
+        if not isinstance(helper, HelperExtAppliesTo)
     ]
     ent.helpers.insert(pos, HelperExtAppliesTo(arg_list))
     return arg_list
@@ -338,7 +345,7 @@ def add_tag(tags: FrozenSet[str], new_tag: str) -> FrozenSet[str]:
 
 def action_count(dbase: Path, extra_db: Optional[Path], plot: bool=False) -> None:
     """Output a count of all entities in the database per game."""
-    fgd = load_database(dbase, extra_db)
+    fgd, base_entity_def = load_database(dbase, extra_db)
 
     count_base: Dict[str, int] = Counter()
     count_point: Dict[str, int] = Counter()
@@ -621,7 +628,7 @@ def action_export(
 
     print('Tags expanded to: {}'.format(', '.join(tags)))
 
-    fgd = load_database(dbase, extra_db)
+    fgd, base_entity_def = load_database(dbase, extra_db)
 
     if engine_mode:
         # In engine mode, we don't care about specific games.
@@ -630,9 +637,7 @@ def action_export(
 
         # Cache these constant sets.
         tags_empty = frozenset('')
-        tags_engine = frozenset({'ENGINE'})
         tags_not_engine = frozenset({'-ENGINE', '!ENGINE'})
-        just_dash = frozenset('-')
 
         print('Merging tags...')
         for ent in fgd:
@@ -646,13 +651,16 @@ def action_export(
             ]
             value: Union[IODef, KeyValues]
             category: Dict[str, Dict[FrozenSet[str], Union[IODef, KeyValues]]]
-            for category in [ent.inputs, ent.outputs, ent.keyvalues]:
+            base_cat: Dict[str, Dict[FrozenSet[str], Union[IODef, KeyValues]]]
+            for attr_name in ['inputs', 'outputs', 'keyvalues']:
+                category = getattr(ent, attr_name)
+                base_cat = getattr(base_entity_def, attr_name)
                 # For each category, check for what value we want to keep.
                 # If only one, we keep that.
                 # If there's an "ENGINE" tag, that's specifically for us.
                 # Otherwise, warn if there's a type conflict.
                 # If the final value is choices, warn too (not really a type).
-                for key, orig_tag_map in category.items():
+                for key, orig_tag_map in list(category.items()):
                     # Remake the map, excluding non-engine tags.
                     # If any are explicitly matching us, just use that
                     # directly.
@@ -672,6 +680,7 @@ def action_export(
 
                     if not tag_map:
                         # All were set as non-engine, so it's not present.
+                        del category[key]
                         continue
                     elif len(tag_map) == 1:
                         # Only one type, that's the one for the engine.
@@ -712,11 +721,47 @@ def action_export(
                                 value.type = ValueTypes.INT
                             value.val_list = None
 
+                    # Check if this is a shared property among all ents,
+                    # and if so skip exporting.
+                    if ent.classname != BASE_ENTITY:
+                        base_value: Union[KeyValues, IODef]
+                        try:
+                            [base_value] = base_cat[key].values()
+                        except KeyError:
+                            pass
+                        except ValueError:
+                            raise ValueError(
+                                f'Base Entity {attr_name[:-1]} "{key}" '
+                                f'has multiple tags: {list(base_cat[key].keys())}'
+                            )
+                        else:
+                            if base_value.type is ValueTypes.CHOICES:
+                                print(
+                                    f'Base Entity {attr_name[:-1]} '
+                                    f'"{key}"  is a choices type!'
+                                )
+                            elif base_value.type is value.type:
+                                del category[key]
+                                continue
+                            else:
+                                print(f'{ent.classname}.{key}: {value.type} != base {base_value.type}')
+                        ent.bases = [base_entity_def]
+
                     # Blank this, it's not that useful.
                     value.desc = ''
-
                     category[key] = {tags_empty: value}
 
+        # Add in the base entity definition, and clear it out.
+        fgd.entities[BASE_ENTITY.casefold()] = base_entity_def
+        base_entity_def.desc = ''
+        base_entity_def.helpers = []
+        # Strip out all the tags.
+        for cat in [base_entity_def.inputs, base_entity_def.outputs, base_entity_def.keyvalues]:
+            for key, tag_map in cat.items():
+                [value] = tag_map.values()
+                cat[key] = {tags_empty: value}
+                if value.type is ValueTypes.CHOICES:
+                    raise ValueError('Choices key in CBaseEntity!')
     else:
         print('Culling incompatible entities...')
 
@@ -832,7 +877,7 @@ def action_visgroup(
     dest: Path,
 ) -> None:
     """Dump all auto-visgroups into the specified file, using a custom format."""
-    fgd = load_database(dbase, extra_loc, fgd_vis=True)
+    fgd, base_entity_def = load_database(dbase, extra_loc, fgd_vis=True)
 
     # TODO: This shouldn't be copied from fgd.export(), need to make the
     #  parenting invariant guaranteed by the classes.


### PR DESCRIPTION
Closes https://github.com/ChaosInitiative/Chaos-FGD/issues/19 (after https://github.com/ChaosInitiative/Chaos-FGD/pull/29)

I originally thought this was the addition of base entity for normal builds (p2ce/momentum), but it is just for engine dumps (running the script with `engine`). Good to have if we do need that in the future, but for now does not change the P2CE/Momentum FGD builds at all.

This also adds some misc fixes from upstream that I missed and an oversight from https://github.com/ChaosInitiative/Chaos-FGD/pull/26 (didnt update all `fadescale` fields)