### PR TITLE
Consolidation of build scripts + github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: FGD Build and Folder Copy
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install srctools
+        run: .\install_srctools.bat
+      - name: FGD build and folder copy
+        run: .\build.bat all
+      - name: Artifact upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: build_${{ runner.os }}-${{ github.sha }}
+          path: ./build/*.fgd
+          if-no-files-found: error
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install srctools
+        run: bash ./install_srctools.sh
+      - name: FGD build and folder copy
+        run: bash ./build.sh all
+      - name: Artifact upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: build_${{ runner.os }}-${{ github.sha }}
+          path: ./build/*.fgd
+          if-no-files-found: error

--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,39 @@
-robocopy hammer build/hammer  /S /PURGE
-robocopy instances build/instances /XF *.vmx /S /PURGE
-robocopy transforms build/postcompiler/transforms /PURGE
-python unify_fgd.py exp p2ce srctools -o "build/p2ce.fgd"
-python unify_fgd.py exp momentum srctools -o "build/momentum.fgd"
+@echo off
+
+SET games=momentum p2ce
+SET game=%1
+
+:: Make sure game isn't empty
+:while
+IF [%game%]==[] (echo Games: %games% & echo Enter game to build. Use ALL to build every game. & SET /P game= & GOTO :while)
+
+IF /I %game%==ALL (
+  CALL :copy_hammer_files
+  (FOR %%i in (%games%) do (
+    CALL :build_game "%%i"
+  ))
+  EXIT
+) ELSE (
+  (FOR %%i in (%games%) do (
+    IF /I %game%==%%i (
+      CALL :copy_hammer_files
+      CALL :build_game %game%
+      EXIT
+    )
+  ))
+  echo Unknown game. Exitting. & EXIT /B 1
+)
+
+:build_game
+  echo Building FGD for %1...
+  py unify_fgd.py exp %1 srctools -o "build/%1.fgd"
+  IF %ERRORLEVEL% NEQ 0 (echo Building FGD for %1 has failed. Exitting. & EXIT)
+  EXIT /B
+
+:copy_hammer_files
+  echo Copying Hammer files...
+  IF %ERRORLEVEL% LSS 8 robocopy hammer build/hammer /S /PURGE
+  IF %ERRORLEVEL% LSS 8 robocopy instances build/instances /XF *.vmx /S /PURGE
+  IF %ERRORLEVEL% LSS 8 robocopy transforms build/postcompiler/transforms /PURGE
+  IF %ERRORLEVEL% LSS 8 EXIT /B 0
+  echo Failed copying Hammer files. Exitting. & EXIT

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,48 @@
 #!/bin/sh
-mkdir -p build
-cp -rf hammer build/hammer
-cp -rf instances build/instances
-cp -rf transforms build/postcompiler/transforms
-find ./build/instances -iname "*.vmx" -delete # Yes, I know that we could use rsync with a ton of options to do this instead of using cp and then deleting unwanted files. This is FAR nicer imo.
-python3 unify_fgd.py exp p2ce srctools -o "build/p2ce.fgd"
-python3 unify_fgd.py exp momentum srctools -o "build/momentum.fgd"
+games="momentum p2ce"
+game=$1
+if [ $# -eq 0 ]; then
+  echo Games: "${games[*]}" & echo Enter game to build. Use ALL to build every game. & read -p "" game
+fi
+
+copy_hammer_files() {
+  echo "Copying Hammer files..."
+  mkdir -p build/postcompiler &&
+  cp -rf hammer build/hammer &&
+  cp -rf instances build/instances &&
+  cp -rf transforms build/postcompiler/transforms &&
+  find ./build/instances -iname "*.vmx" -delete # Yes, I know that we could use rsync with a ton of options to do this instead of using cp and then deleting unwanted files. This is FAR nicer imo.
+  
+  if [ $? -ne 0 ]; then
+    echo "Failed copying Hammer files. Exitting." & exit 1
+  fi
+  return 0
+}
+
+build_game() {
+  echo "Building FGD for $1..."
+  python3 unify_fgd.py exp $1 srctools -o "build/$1.fgd"
+  
+  if [ $? -ne 0 ]; then
+    echo "Building FGD for $1 has failed. Exitting." & exit 1
+  fi
+  return 0
+}
+
+if [ "${game^^}" = "ALL" ]; then 
+  copy_hammer_files
+  for i in $games 
+    do
+    build_game $i
+  done
+else
+  for i in $games
+    do
+    if [ "$i" = "$game" ]; then 
+      copy_hammer_files
+      build_game $game
+      exit
+    fi
+    echo "Unknown game. Exitting." & exit 1
+  done
+fi

--- a/build_momentum.bat
+++ b/build_momentum.bat
@@ -1,5 +1,0 @@
-robocopy hammer build/hammer  /S /PURGE
-robocopy instances build/instances /XF *.vmx /S /PURGE
-robocopy transforms build/postcompiler/transforms /PURGE
-python unify_fgd.py exp momentum srctools -o "build/momentum.fgd"
-pause

--- a/build_momentum.sh
+++ b/build_momentum.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-mkdir -p build
-cp -rf hammer build/hammer 
-cp -rf instances build/instances
-cp -rf transforms build/postcompiler/transforms
-python3 unify_fgd.py exp momentum srctools -o "build/momentum.fgd"

--- a/build_p2ce.bat
+++ b/build_p2ce.bat
@@ -1,5 +1,0 @@
-robocopy hammer build/hammer  /S /PURGE
-robocopy instances build/instances /XF *.vmx /S /PURGE
-robocopy transforms build/postcompiler/transforms /PURGE
-python unify_fgd.py exp p2ce srctools -o "build/p2ce.fgd"
-pause

--- a/build_p2ce.sh
+++ b/build_p2ce.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-mkdir -p build
-cp -rf hammer build/hammer 
-cp -rf instances build/instances
-cp -rf transforms build/postcompiler/transforms
-python3 unify_fgd.py exp p2ce srctools -o "build/p2ce.fgd"

--- a/install_srctools.bat
+++ b/install_srctools.bat
@@ -1,1 +1,1 @@
-pip install -e git+https://github.com/TeamSpen210/srctools.git#egg=srctools
+py -m pip install -e git+https://github.com/TeamSpen210/srctools.git#egg=srctools

--- a/install_srctools.sh
+++ b/install_srctools.sh
@@ -1,0 +1,1 @@
+python3 -m pip install -e git+https://github.com/TeamSpen210/srctools.git#egg=srctools


### PR DESCRIPTION
Closes https://github.com/ChaosInitiative/Chaos-FGD/issues/21
Closes https://github.com/ChaosInitiative/Chaos-FGD/issues/23

Consolidates build scripts into one, with a menu, for both linux and windows.

Adds a github action that builds the FGD & copies folders over, using the new scripts. Has both linux and windows build jobs. 
Action also uploads an artifact for each job which contains only the built FGDs to speed up and lower size of upload (folders are just copied and so we can get them from the repo).

Also I found that linux and windows building is not the same. Linux specifically fails to have some `sphere(*)`'s present in the windows build. It's either a `unify_fgd.py` or srctools issue, which can be remedied later. For now it'd be best to use the windows artifact if for whatever reason we need it.

Might want to make master protected now. I don't think we need a dev branch so I didn't add that as a trigger.