### PR TITLE
Fix trigger & teleport trigger spawnflags

### DIFF
--- a/fgd/bases/TeleTrigger.fgd
+++ b/fgd/bases/TeleTrigger.fgd
@@ -41,6 +41,20 @@
 	
 	spawnflags(flags) =
 		[
+		32: "Preserve angles even when a local landmark is not specified" : 0
 		8388608: "Teleport the player on EndTouch() instead of StartTouch()" : 0
+		
+		// Restore the other spawnflags.
+		1: "Clients/Players" : 1
+		8192: "Allow ghosts to fire this trigger" : 0 [MOMENTUM]
+		2: "NPCs" : 0
+		4: "func_pushable" : 0
+		8: "Physics Objects" : 0
+		16: "Only player ally NPCs" : 0
+		64: "Everything (not including physics debris)" : 0
+		512: "Only clients *not* in vehicles" : 0
+		1024: "Physics debris" : 0
+		2048: "Only NPCs in vehicles (respects player ally flag)" : 0
+		4096: "Correctly account for object mass (trigger_push used to assume 100Kg) and multiple component physobjs (car, blob...)" : 1
 		]
 	]

--- a/fgd/bases/Trigger.fgd
+++ b/fgd/bases/Trigger.fgd
@@ -1,24 +1,6 @@
 @BaseClass base(TriggerOnce)
 = Trigger
 	[
-	spawnflags(flags)  =
-		[
-		32: "Preserve angles even when a local landmark is not specified" : 0
-
-		// Restore the other spawnflags.
-		1: "Clients/Players" : 1
-		2: "NPCs" : 0
-		4: "func_pushable" : 0
-		8: "Physics Objects" : 0
-		16: "Only player ally NPCs" : 0
-		64: "Everything (not including physics debris)" : 0
-		512: "Only clients *not* in vehicles" : 0
-		1024: "Physics debris" : 0
-		2048: "Only NPCs in vehicles (respects player ally flag)" : 0
-		4096: "Correctly account for object mass (trigger_push used to assume 100Kg) and multiple component physobjs (car, blob...)" : 1
-		8192: "Allow ghosts to fire this trigger" [MOMENTUM]
-		]
-
 	// Inputs
     input EndTouch(void) : "Fires the OnEndTouch output. If called by an entity inside the trigger, the OnEndTouch will be fired for them as the activator. Note that this input is passed even if the player is being treated as 'not' touching the trigger while outside it."
 

--- a/fgd/bases/TriggerOnce.fgd
+++ b/fgd/bases/TriggerOnce.fgd
@@ -3,9 +3,10 @@
 	line(255 255 255, targetname, filtername) 
 = TriggerOnce
 	[
-	spawnflags(flags)  =
+	spawnflags(flags) =
 		[
 		1: "Clients/Players" : 1
+		8192: "Allow ghosts to fire this trigger" : 0 [MOMENTUM]
 		2: "NPCs" : 0
 		4: "func_pushable" : 0
 		8: "Physics Objects" : 0

--- a/fgd/brush/trigger/trigger_teleport.fgd
+++ b/fgd/brush/trigger/trigger_teleport.fgd
@@ -1,12 +1,4 @@
-@SolidClass base(Trigger)
-	appliesto(-MOMENTUM)
-	line(255 255 255, targetname, filtername)
-	line(255 255 0, targetname, target)
-	line(0 255 0, target, landmark)
-= trigger_teleport: "A trigger volume that teleports entities that touch it. " +
-	"Entities are teleported to the Remote Destination, and have their angles set to that of the Remote Destination's. " +
-	"If a Local Destination Landmark is specified, teleported entities are offset from " +
-	"the target by their initial offset from the landmark, and their angles are left alone."
+@BaseClass appliesto(-MOMENTUM) base(Trigger) = _trigger_teleport
 	[
 	spawnflags(flags) =
 		[
@@ -36,9 +28,9 @@
 	// Inputs
 	input SetRemoteDestination(string) : "Set a new target to teleport to."
 	]
+@BaseClass appliesto(+MOMENTUM) base(TeleTrigger) = _trigger_teleport_mom []
 
-@SolidClass base(TeleTrigger)
-	appliesto(+MOMENTUM)
+@SolidClass base(_trigger_teleport, _trigger_teleport_mom)
 	line(255 255 255, targetname, filtername)
 	line(255 255 0, targetname, target)
 	line(0 255 0, target, landmark)

--- a/fgd/brush/trigger/trigger_teleport.fgd
+++ b/fgd/brush/trigger/trigger_teleport.fgd
@@ -8,6 +8,23 @@
 	"If a Local Destination Landmark is specified, teleported entities are offset from " +
 	"the target by their initial offset from the landmark, and their angles are left alone."
 	[
+	spawnflags(flags) =
+		[
+		32: "Preserve angles even when a local landmark is not specified" : 0
+
+		// Restore the other spawnflags.
+		1: "Clients/Players" : 1
+		2: "NPCs" : 0
+		4: "func_pushable" : 0
+		8: "Physics Objects" : 0
+		16: "Only player ally NPCs" : 0
+		64: "Everything (not including physics debris)" : 0
+		512: "Only clients *not* in vehicles" : 0
+		1024: "Physics debris" : 0
+		2048: "Only NPCs in vehicles (respects player ally flag)" : 0
+		4096: "Correctly account for object mass (trigger_push used to assume 100Kg) and multiple component physobjs (car, blob...)" : 1
+		]
+
 	target(target_destination) : "Remote Destination" : : "The entity specifying the point to which entities should be teleported."
 	landmark(target_destination) : "Local Destination Landmark" : : "If specified, then teleported entities are offset " +
 		"from the target by their initial offset from the landmark."


### PR DESCRIPTION
Closes https://github.com/ChaosInitiative/Chaos-FGD/issues/31

When I added momentum to the repo, I made a mistake with trigger spawnflags in general, mainly as I didn't understand the cases where spawnflags need to be "restored" if one of them differs (by number) from one of the bases: https://github.com/ChaosInitiative/Chaos-FGD/pull/15/commits/caf97de3a66a3e4ae477ed2eaa2f2ff4132b120c. This change fixes trigger & trigger_teleport spawnflags, while also defaulting Clients/Players spawnflag to on *only* for teleports.

Also, P2CE was not including `trigger_teleport`. This is because the parser can only parse one entity definition. The solution here is to have 2 empty `BaseClass`'s basing off of different entities (`Trigger` vs. momentum's `TeleTrigger`). Only caveat is that it shows those bases in the FGD, though they aren't shown in hammer.
This is done for some entities to account for different tags (see https://github.com/TeamSpen210/HammerAddons/blob/master/fgd/point/item/item_ammo_357.fgd).

The teleport FGDs are quite a mess at the moment, but will be remedied when we properly merge momentum's changes into the base engine.