### PR TITLE
Fix func_dustmotes & func_dustcloud fields

### DIFF
--- a/fgd/bases/BaseDustParticleSpawner.fgd
+++ b/fgd/bases/BaseDustParticleSpawner.fgd
@@ -11,6 +11,7 @@
 	color(color255) : "Particle Color (R G B)" : "255 255 255"
 	spawnrate(integer) : "Particle Per Second" : 40 : "Number of particles to spawn, per second."
 	speedmax(integer) : "Maximum Particle Speed" : 13 : "Maximum speed that the particles can move after spawning."
+	fallspeed(integer) : "Particle Fall Speed" : 0 : "How fast the particles fall to the ground. This value is subtracted from the particle speed in the Z-axis only."
 	lifetimemin(integer) : "Minimum Particle Lifetime" : 3 : "Minimum number of seconds until each particle dies. Particles live for a random duration between this and 'Maximum Particle Lifetime'."
 	lifetimemax(integer) : "Maximum Particle Lifetime" : 5 : "Maximum number of seconds until each particle dies. Particles live for a random duration between 'Minimum Particle Lifetime' and this. Will be clamped to a max of 15."
 	distmax(integer) : "Maximum Visible Distance" : 1024 : "Maximum distance at which particles are visible. They fade to translucent at this distance."

--- a/fgd/bases/BaseDustParticleSpawner.fgd
+++ b/fgd/bases/BaseDustParticleSpawner.fgd
@@ -15,7 +15,7 @@
 	lifetimemax(integer) : "Maximum Particle Lifetime" : 5 : "Maximum number of seconds until each particle dies. Particles live for a random duration between 'Minimum Particle Lifetime' and this. Will be clamped to a max of 15."
 	distmax(integer) : "Maximum Visible Distance" : 1024 : "Maximum distance at which particles are visible. They fade to translucent at this distance."
 	frozen(boolean) : "Frozen" : 0 : "When set, this entity spawns the number of particles in SpawnRate immediately, and then goes inactive."
-	nowind(boolean) : "Unaffected by Wind" : 0 : "When set, wind doesn't affect the particles of this entity."
+	affectedbywind(boolean) : "Affected by Wind" : 1 : "When set, the dust will be affected by any env_wind entity settings in the map."
 
 	// Inputs
 	input TurnOn(void) : "Turn on."

--- a/fgd/bases/BaseDustParticleSpawner.fgd
+++ b/fgd/bases/BaseDustParticleSpawner.fgd
@@ -1,6 +1,6 @@
 @BaseClass 
 	sphere(distmax)
-= BModelParticleSpawner
+= BaseDustParticleSpawner
 	[
 	// These two values break dustmotes.
 	solid[engine](integer) : "Solid" : 0

--- a/fgd/bases/BaseDustParticleSpawner.fgd
+++ b/fgd/bases/BaseDustParticleSpawner.fgd
@@ -2,13 +2,10 @@
 	sphere(distmax)
 = BaseDustParticleSpawner
 	[
-	// These two values break dustmotes.
-	solid[engine](integer) : "Solid" : 0
-	solid(choices) readonly: "Solid" : 0 : "This needs to be zero to allow this to not collide." = 
-		[
-		0: "Non-solid"
-		]
-	origin(origin) readonly: "Origin": "" : "If offset, this breaks."
+	targetname(target_source) : "Name" : : "The name that other entities refer to this entity by."
+
+	vscripts[VSCRIPT](scriptlist) : "Entity Scripts" : : "Name(s) of script files that are executed after all entities have spawned."
+	thinkfunction[VSCRIPT](string) : "Script think function" : : "Name of a function in this entity's script scope which will be called automatically."
 
 	startdisabled(boolean) : "Start Disabled" : 0
 	color(color255) : "Particle Color (R G B)" : "255 255 255"

--- a/fgd/brush/func/func_dustcloud.fgd
+++ b/fgd/brush/func/func_dustcloud.fgd
@@ -1,6 +1,6 @@
 @SolidClass base(BaseDustParticleSpawner) = func_dustcloud: "A brush entity that spawns a translucent dust cloud within its volume."
 	[
-	alpha(integer) : "Alpha" : 30
-	sizemin(string) : "Minimum Particle Size" : 100
-	sizemax(string) : "Maximum Particle Size" : 200
+	sizemin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."
+	sizemax(string) : "Maximum Particle Size" : 200 : "This value determines the maximum size the particles can be."
+	alpha(integer) : "Particle Translucency (0 - 255)" : 30 : "Translucency of the particles."
 	]

--- a/fgd/brush/func/func_dustcloud.fgd
+++ b/fgd/brush/func/func_dustcloud.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityBrush, BaseDustParticleSpawner) = func_dustcloud: "A brush entity that spawns a translucent dust cloud within its volume."
+@SolidClass base(BaseDustParticleSpawner) = func_dustcloud: "A brush entity that spawns a translucent dust cloud within its volume."
 	[
 	alpha(integer) : "Alpha" : 30
 	sizemin(string) : "Minimum Particle Size" : 100

--- a/fgd/brush/func/func_dustcloud.fgd
+++ b/fgd/brush/func/func_dustcloud.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityBrush, BModelParticleSpawner) = func_dustcloud: "A brush entity that spawns a translucent dust cloud within its volume."
+@SolidClass base(BaseEntityBrush, BaseDustParticleSpawner) = func_dustcloud: "A brush entity that spawns a translucent dust cloud within its volume."
 	[
 	alpha(integer) : "Alpha" : 30
 	sizemin(string) : "Minimum Particle Size" : 100

--- a/fgd/brush/func/func_dustmotes.fgd
+++ b/fgd/brush/func/func_dustmotes.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityBrush, BaseDustParticleSpawner) = func_dustmotes: "A brush entity that spawns sparkling dust motes within its volume."
+@SolidClass base(BaseDustParticleSpawner) = func_dustmotes: "A brush entity that spawns sparkling dust motes within its volume."
 	[
 	Alpha(integer) : "Particle Translucency (0 - 255)" : 30 : "Translucency of the particles."
 	SizeMin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."

--- a/fgd/brush/func/func_dustmotes.fgd
+++ b/fgd/brush/func/func_dustmotes.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityBrush, BModelParticleSpawner) = func_dustmotes: "A brush entity that spawns sparkling dust motes within its volume."
+@SolidClass base(BaseEntityBrush, BaseDustParticleSpawner) = func_dustmotes: "A brush entity that spawns sparkling dust motes within its volume."
 	[
 	Alpha(integer) : "Particle Translucency (0 - 255)" : 30 : "Translucency of the particles."
 	SizeMin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."

--- a/fgd/brush/func/func_dustmotes.fgd
+++ b/fgd/brush/func/func_dustmotes.fgd
@@ -1,6 +1,6 @@
 @SolidClass base(BaseDustParticleSpawner) = func_dustmotes: "A brush entity that spawns sparkling dust motes within its volume."
 	[
-	Alpha(integer) : "Particle Translucency (0 - 255)" : 30 : "Translucency of the particles."
-	SizeMin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."
-	SizeMax(string) : "Maximum Particle Size" : 200 : "This value determines the maximum size the particles can be."
+	sizemin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."
+	sizemax(string) : "Maximum Particle Size" : 200 : "This value determines the maximum size the particles can be."
+	alpha(integer) : "Particle Translucency (0 - 255)" : 30 : "Translucency of the particles."
 	]

--- a/fgd/brush/func/func_dustmotes.fgd
+++ b/fgd/brush/func/func_dustmotes.fgd
@@ -1,6 +1,6 @@
 @SolidClass base(BaseDustParticleSpawner) = func_dustmotes: "A brush entity that spawns sparkling dust motes within its volume."
 	[
-	sizemin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."
-	sizemax(string) : "Maximum Particle Size" : 200 : "This value determines the maximum size the particles can be."
-	alpha(integer) : "Particle Translucency (0 - 255)" : 30 : "Translucency of the particles."
+	sizemin(string) : "Minimum Particle Size" : 10 : "This value determines the minimum size the particles can be."
+	sizemax(string) : "Maximum Particle Size" : 20 : "This value determines the maximum size the particles can be."
+	alpha(integer) : "Particle Translucency (0 - 255)" : 255 : "Translucency of the particles."
 	]

--- a/fgd/brush/func/func_dustmotes.fgd
+++ b/fgd/brush/func/func_dustmotes.fgd
@@ -3,7 +3,4 @@
 	Alpha(integer) : "Particle Translucency (0 - 255)" : 30 : "Translucency of the particles."
 	SizeMin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."
 	SizeMax(string) : "Maximum Particle Size" : 200 : "This value determines the maximum size the particles can be."
-
-	input TurnOn(void) : "Turn on."
-	input TurnOff(void) : "Turn off."
 	]

--- a/fgd/brush/func/func_dustmotes.fgd
+++ b/fgd/brush/func/func_dustmotes.fgd
@@ -4,7 +4,6 @@
 	SizeMin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."
 	SizeMax(string) : "Maximum Particle Size" : 200 : "This value determines the maximum size the particles can be."
 	FallSpeed(integer) : "Particle Fall Speed" : : "How fast the particles fall to the ground."
-	affectedbywind(boolean) : "Affected By Wind" : 1 : "When set, the dust will be affected by any env_wind entity settings in the map."
 
 	input TurnOn(void) : "Turn on."
 	input TurnOff(void) : "Turn off."

--- a/fgd/brush/func/func_dustmotes.fgd
+++ b/fgd/brush/func/func_dustmotes.fgd
@@ -3,7 +3,6 @@
 	Alpha(integer) : "Particle Translucency (0 - 255)" : 30 : "Translucency of the particles."
 	SizeMin(string) : "Minimum Particle Size" : 100 : "This value determines the minimum size the particles can be."
 	SizeMax(string) : "Maximum Particle Size" : 200 : "This value determines the maximum size the particles can be."
-	FallSpeed(integer) : "Particle Fall Speed" : : "How fast the particles fall to the ground."
 
 	input TurnOn(void) : "Turn on."
 	input TurnOff(void) : "Turn off."


### PR DESCRIPTION
From a Discord bug report by Kappaeliitti, `func_dustmotes`:
![image](https://user-images.githubusercontent.com/9014762/116022476-1f947a80-a5ff-11eb-8940-7f998b48572a.png)

Also found other discrepancies, explained in the commits.

Compared this to our code & to CSGO's FGD for accuracy:
![image](https://user-images.githubusercontent.com/9014762/116022705-90d42d80-a5ff-11eb-89ae-be890a58d842.png)
![image](https://user-images.githubusercontent.com/9014762/116022746-a5182a80-a5ff-11eb-943d-a9eb4733dec9.png)
