### PR TITLE
fix: Switch to using python for windows scripts

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -26,7 +26,7 @@ IF /I %game%==ALL (
 
 :build_game
   echo Building FGD for %1...
-  py unify_fgd.py exp %1 srctools -o "build/%1.fgd"
+  python unify_fgd.py exp %1 srctools -o "build/%1.fgd"
   IF %ERRORLEVEL% NEQ 0 (echo Building FGD for %1 has failed. Exitting. & EXIT)
   EXIT /B
 

--- a/install_srctools.bat
+++ b/install_srctools.bat
@@ -1,1 +1,1 @@
-py -m pip install -e git+https://github.com/TeamSpen210/srctools.git#egg=srctools
+python -m pip install -e git+https://github.com/TeamSpen210/srctools.git#egg=srctools


### PR DESCRIPTION
"Py" is a launcher for windows python that while convenient, is not necessary and messes up the builder bots we use to deploy