### PR TITLE
fix: Change default lightmap scale to 16, originally was 128

### DIFF
--- a/hammer/cfg/GameConfig_default.txt
+++ b/hammer/cfg/GameConfig_default.txt
@@ -8,7 +8,7 @@
         {
             "GameData0"		"..\..\p2ce\p2ce.fgd"
             "DefaultTextureScale"		"0.250000"
-            "DefaultLightmapScale"		"128"
+            "DefaultLightmapScale"		"16"
             "GameExe"		"chaos.exe"
             "DefaultSolidEntity"		"func_detail"
             "DefaultPointEntity"		"info_player_start"


### PR DESCRIPTION
This led to some confusion with paint not working properly in custom p2ce maps by default. 