### PR TITLE
Add zonmaker pre-compile steps

### DIFF
--- a/hammer/cfg_momentum/CmdSeqDefault.wc
+++ b/hammer/cfg_momentum/CmdSeqDefault.wc
@@ -13,6 +13,28 @@
         {
             "enabled" "1"
             "special_cmd" "0"
+            "run" "zonmaker.exe"
+            "params" "$path\$file.vmf"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "2"
+        {
+            "enabled" "1"
+            "special_cmd" "261" // Copy File if it exists
+            "run" ""
+            "params" "$path\$file.zon $bspdir\..\zones\$file.zon"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "3"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
             "run" "$bsp_exe"
             "params" "-game $gamedir $path\$file"
             "ensure_check" "0"
@@ -20,7 +42,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "2"
+        "4"
         {
             "enabled" "0"
             "special_cmd" "0"
@@ -31,7 +53,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "3"
+        "5"
         {
             "enabled" "1"
             "special_cmd" "0"
@@ -42,7 +64,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "4"
+        "6"
         {
             "enabled" "1"
             "special_cmd" "0"
@@ -53,7 +75,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "5"
+        "7"
         {
             "enabled" "1"
             "special_cmd" "257" // Copy File
@@ -64,7 +86,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "6"
+        "8"
         {
             "enabled" "1"
             "special_cmd" "0"
@@ -82,6 +104,28 @@
         {
             "enabled" "1"
             "special_cmd" "0"
+            "run" "zonmaker.exe"
+            "params" "$path\$file.vmf"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "2"
+        {
+            "enabled" "1"
+            "special_cmd" "261" // Copy File if it exists
+            "run" ""
+            "params" "$path\$file.zon $bspdir\..\zones\$file.zon"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "3"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
             "run" "$bsp_exe"
             "params" "-game $gamedir $path\$file"
             "ensure_check" "0"
@@ -89,7 +133,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "2"
+        "4"
         {
             "enabled" "0"
             "special_cmd" "0"
@@ -100,7 +144,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "3"
+        "5"
         {
             "enabled" "1"
             "special_cmd" "0"
@@ -111,7 +155,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "4"
+        "6"
         {
             "enabled" "1"
             "special_cmd" "0"
@@ -122,7 +166,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "5"
+        "7"
         {
             "enabled" "1"
             "special_cmd" "257" // Copy File
@@ -133,7 +177,7 @@
             "use_process_wnd" "1"
             "no_wait" "0"
         }
-        "6"
+        "8"
         {
             "enabled" "0"
             "special_cmd" "0"

--- a/hammer/cfg_momentum/CmdSeqDefault.wc
+++ b/hammer/cfg_momentum/CmdSeqDefault.wc
@@ -21,7 +21,7 @@
         }
         "2"
         {
-            "enabled" "1"
+            "enabled" "0"
             "special_cmd" "0"
             "run" "$postcompiler_exe"
             "params" "--propcombine $path\$file"
@@ -90,7 +90,7 @@
         }
         "2"
         {
-            "enabled" "1"
+            "enabled" "0"
             "special_cmd" "0"
             "run" "$postcompiler_exe"
             "params" "--propcombine $path\$file"

--- a/hammer/cfg_momentum/CmdSeqDefault.wc
+++ b/hammer/cfg_momentum/CmdSeqDefault.wc
@@ -5,6 +5,7 @@
     // 257 - Copy File
     // 258 - Delete File
     // 259 - Rename File
+    // 261 - Copy File if it exists
     // And they have no "run" string
     "Fast"
     {

--- a/hammer/cfg_p2ce/CmdSeqDefault.wc
+++ b/hammer/cfg_p2ce/CmdSeqDefault.wc
@@ -5,6 +5,7 @@
     // 257 - Copy File
     // 258 - Delete File
     // 259 - Rename File
+    // 261 - Copy File if it exists
     // And they have no "run" string
     "Fast"
     {


### PR DESCRIPTION
Closes https://github.com/ChaosInitiative/Chaos-FGD/issues/54

Creates the `.zon` file and copies it over to game, using the newly added special cmd so that trying to copy a non-existent `.zon` file doesnt fail the compile.

I do also have some code changes that allows this to be nicer, so that the zonmaker executable can be run with `$zonmaker_exe` and the zones folder can be found with `$zondir`.. though it required a lot of `MOMENTUM` ifdefs so I elected to go this route. Can always go the other route, would be nice to have zonmaker run on normal compiles too.