### PR TITLE
Move physcannon only spawnflag out of base Weapon

### DIFF
--- a/fgd/bases/Weapon.fgd
+++ b/fgd/bases/Weapon.fgd
@@ -6,7 +6,6 @@
 		[
 		1: "Start constrained" : 0
 		2: "Deny player pickup (reserve for NPC)" : 0 [-MOMENTUM]
-		4: "Not puntable by Gravity Gun" : 0 [+HL2_ENTITIES]
 		]
 
 	// Outputs

--- a/fgd/point/weapon/weapon_physcannon.fgd
+++ b/fgd/point/weapon/weapon_physcannon.fgd
@@ -3,4 +3,12 @@
 	studioprop("models/weapons/w_physics.mdl") 
 = weapon_physcannon: "The Zero-Point Energy Field Manipulator, AKA Gravity Gun."
 	[
+	spawnflags(flags)  =
+		[
+		// restore base's spawnflags
+		1: "Start constrained" : 0
+		2: "Deny player pickup (reserve for NPC)" : 0 [-MOMENTUM]
+
+		4: "Not puntable by Gravity Gun" : 0
+		]
 	]


### PR DESCRIPTION
In code, this is only used for the physcannon