### PR TITLE
New kv to control a light's fadespeed

### DIFF
--- a/fgd/bases/BaseLight.fgd
+++ b/fgd/bases/BaseLight.fgd
@@ -27,6 +27,7 @@
 		12 : "Underwater light mutation"
 	]
 	pattern(string) : "Custom Appearance" : "" : "Set a custom pattern of light brightness for this light. Pattern format is a string of characters, where 'a' is total darkness, 'z' fully bright. i.e. 'aaggnnttzz' would be a steppy fade in from dark to light."
+	fadetickinterval(integer) : "Fade Tick Interval" : "0.1" : "The tick interval of the light's fade, in seconds. Lower values cause a faster fade."
 	_constant_attn(string)	: "Constant" : "0"
 	_linear_attn(string)	: "Linear" : "0"
 	_quadratic_attn(string)	: "Quadratic" : "1"

--- a/fgd/point/env/env_cascade_light.fgd
+++ b/fgd/point/env/env_cascade_light.fgd
@@ -3,7 +3,7 @@
 	lightprop("models/editor/spot.mdl") 
 = env_cascade_light: "An entity to control the sunlight that casts cascaded shadows in the map."
 	[
-	angles(angle) : "Pitch Yaw Roll (Y Z X)" : "50 40 0" : "This is the shadow casting direction. " +
+	angles(angle) : "Pitch Yaw Roll (Y Z X)" : "50 43 0" : "This is the shadow casting direction. " +
 		"Pitch is rotation around the Y axis, " +
 		"yaw is the rotation around the Z axis, and " +
 		"roll is the rotation around the X axis. " +


### PR DESCRIPTION
Adds `fadetickinterval` kv to `BaseLight`, which can control the speed of the light's fade. Goes together with the internal PR adding it.