### PR TITLE
Fix fadetickinterval using wrong type, preventing some light ents from showing up in hammer

### DIFF
--- a/fgd/bases/BaseLight.fgd
+++ b/fgd/bases/BaseLight.fgd
@@ -27,7 +27,7 @@
 		12 : "Underwater light mutation"
 	]
 	pattern(string) : "Custom Appearance" : "" : "Set a custom pattern of light brightness for this light. Pattern format is a string of characters, where 'a' is total darkness, 'z' fully bright. i.e. 'aaggnnttzz' would be a steppy fade in from dark to light."
-	fadetickinterval(integer) : "Fade Tick Interval" : "0.1" : "The tick interval of the light's fade, in seconds. Lower values cause a faster fade."
+	fadetickinterval(float) : "Fade Tick Interval" : 0.1 : "The tick interval of the light's fade, in seconds. Lower values cause a faster fade."
 	_constant_attn(string)	: "Constant" : "0"
 	_linear_attn(string)	: "Linear" : "0"
 	_quadratic_attn(string)	: "Quadratic" : "1"


### PR DESCRIPTION
Fixes an error introduced in https://github.com/ChaosInitiative/Chaos-FGD/pull/72/files

Going forward, using a quoted value for integers will prevent the effected entities from showing up in hammer, though some float values have quotes and others dont.. weird.

Will require a code change as well as it is expecting an int for some reason (idk what i was smoking).