### PR TITLE
Put prop_linked_portal_door behind P2CE

### DIFF
--- a/fgd/point/prop/prop_linked_portal_door.fgd
+++ b/fgd/point/prop/prop_linked_portal_door.fgd
@@ -1,5 +1,5 @@
 @PointClass base(BaseEntityAnimating, LinkedPortalDoor) 
-	appliesto(+USE_PORTALS) 
+	appliesto(+USE_PORTALS, P2CE) 
 	studioprop("models/props/portal_door.mdl") 
 	line(255 255 0, targetname, lightingorigin) 
 = prop_linked_portal_door: "A door which is linked by a portal to another 'prop_linked_portal_door' entity. " +


### PR DESCRIPTION
Closes https://github.com/momentum-mod/game/issues/1440

This seems be tied to portal 2, as it is literally a portal 2 door with a portal built in. Going this route rather than adding portal door materials to platform.