### PR TITLE
Default teleport resetang to off for P2CE

### DIFF
--- a/fgd/bases/TeleTrigger.fgd
+++ b/fgd/bases/TeleTrigger.fgd
@@ -39,7 +39,8 @@
 	reorient_landmark(boolean) : "Reorient Landmark" : 0 : "(Landmark mode only) Reorient origin, angles and velocity from the landmark's" + 
 		"local space to the destination's. This means the destination room does not have to face the same way."
 	
-	resetang(boolean) : "Reset the player angles on teleport" : 1
+	resetang[+P2CE](boolean) : "Reset the player angles on teleport" : 0
+	resetang[-P2CE](boolean) : "Reset the player angles on teleport" : 1
 
 	fail[MOMENTUM](boolean) : "Teleport is for failing a level" : 0
 	


### PR DESCRIPTION
Portal's teleports default to not resetting angles, whereas other games (2013 and older mainly) dont. There is already an ifdef in code for this default.