### PR TITLE
Use correct base for momentum baselined triggers

### DIFF
--- a/fgd/brush/func/func_nogrenades.fgd
+++ b/fgd/brush/func/func_nogrenades.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(StaticTargetName, EnableDisable, Toggle) 
+@SolidClass base(Trigger) 
 	appliesto(MOMENTUM)
 = func_nogrenades : "Rockets, stickybombs, conc grenades, and other explosives will not detonate/explode inside this area."
 	[

--- a/fgd/brush/trigger/trigger_reversespeed.fgd
+++ b/fgd/brush/trigger/trigger_reversespeed.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(StaticTargetName, EnableDisable, Toggle)
+@SolidClass base(Trigger)
 = trigger_reversespeed : "Trigger for reversing the speed of the player." 
 [
 	ReverseHorizontal(integer) : "Reverse horizontal speed" : 1 : "Reverse accordingly the velocity based on x/y axis."

--- a/fgd/brush/trigger/trigger_setspeed.fgd
+++ b/fgd/brush/trigger/trigger_setspeed.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(StaticTargetName, EnableDisable, Toggle)
+@SolidClass base(Trigger)
 = trigger_setspeed : "Trigger for setting speed of the player." 
 	[
 	KeepHorizontalSpeed(integer) : "Keep horizontal speed" : 0 : "If you want to keep the horizontal (x/y axis velocity based) speed, set it to 1."

--- a/fgd/brush/trigger/trigger_stick_explosive.fgd
+++ b/fgd/brush/trigger/trigger_stick_explosive.fgd
@@ -1,8 +1,7 @@
-@SolidClass base(StaticTargetName, EnableDisable, Toggle) 
+@SolidClass base(Trigger) 
 	appliesto(MOMENTUM)
 = trigger_stick_explosive : "Conc grenades, stickybombs, and other explosives will stick to or inside this area."
 	[
-	startdisabled(boolean) : "Start Disabled" : 0
 	stick_type[engine](integer) : "Method of explosive stick." : 0
 	stick_type(choices) : "Method of explosive stick." : 0 =
 		[

--- a/fgd/brush/trigger/trigger_userinput.fgd
+++ b/fgd/brush/trigger/trigger_userinput.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(StaticTargetName, EnableDisable, Toggle)
+@SolidClass base(Trigger)
 = trigger_userinput : "Trigger that fires on user KeyPress if inside trigger."
 	[
 	output OnKeyPressed(void) : "Fires when the desired key is pressed"


### PR DESCRIPTION
Fixes a dumb mistake introduced in https://github.com/ChaosInitiative/Chaos-FGD/commit/66c811dc7198b1f73cd8ac202494d96d6b5273a0# and some momentum specific triggers. Seems that they should all just be using the trigger base as they inherit from it in code.