### PR TITLE
Default "lightworld" in "env_projectedtexture" to on (as in Portal 2)

### DIFF
--- a/fgd/point/env/env_projectedtexture.fgd
+++ b/fgd/point/env/env_projectedtexture.fgd
@@ -29,7 +29,7 @@
 		]
 
 	lightonlytarget(boolean) : "Light Only Target" : 0 : "Limit flashlight effect to only effect target entity."
-	lightworld(boolean) : "Light World" : 0 : "Control whether flashlight effects static world geometry."
+	lightworld(boolean) : "Light World" : 1 : "Control whether flashlight effects static world geometry."
 	simpleprojection(boolean) : "Simple Projection" : 0 : "Indicates if this is a simple, non-light casting texture projection"
 
 	lightcolor(color255) : "Light Color" : "255 255 255 200" : "Light Color RGB-Intensity"


### PR DESCRIPTION
Closes https://github.com/ChaosInitiative/Chaos-FGD/issues/81

Portal 2 also has `enableshadows` off by default whereas we have it on, but imo it makes sense to have it on by default.