### PR TITLE
Dont mark parallax_obb as P2CE only

### DIFF
--- a/fgd/brush/parallax_obb.fgd
+++ b/fgd/brush/parallax_obb.fgd
@@ -1,4 +1,4 @@
-@SolidClass appliesto(-engine, P2CE)
+@SolidClass appliesto(-engine)
 = parallax_obb : "Bounding box for Parallax Corrected Cubemaps."
 [
 	targetname(target_source) : "Name" : : "The name that other entities refer to this entity by."


### PR DESCRIPTION
This was missed in the big pass we did when adding momentum. The field in `env_cubemap` is not p2ce only though.