### PR TITLE
Pin srctools to the current version, update Python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install srctools
         run: python -m pip install srctools==2.2.3
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install srctools
         run: python3 -m pip install srctools==2.2.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install srctools
-        run: .\install_srctools.bat
+        run: python -m pip install srctools==2.2.3
 
       - name: FGD build and folder copy
         run: .\build.bat all
@@ -41,7 +41,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install srctools
-        run: bash ./install_srctools.sh
+        run: python3 -m pip install srctools==2.2.3
 
       - name: FGD build and folder copy
         run: bash ./build.sh all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install srctools
         run: python -m pip install srctools==2.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install srctools
-        run: .\install_srctools.bat
+        run: python -m pip install srctools==2.2.3
 
       - name: FGD build and folder copy
         run: .\build.bat all

--- a/install_srctools.bat
+++ b/install_srctools.bat
@@ -1,1 +1,0 @@
-python -m pip install -e git+https://github.com/TeamSpen210/srctools.git#egg=srctools

--- a/install_srctools.sh
+++ b/install_srctools.sh
@@ -1,1 +1,0 @@
-python3 -m pip install -e git+https://github.com/TeamSpen210/srctools.git#egg=srctools


### PR DESCRIPTION
Srctools is now properly on PyPI, so this can instead install from the wheels pushed there instead of compiling from source every time. This also ensures I'll can do things like change functionality or remove deprecated code without breaking builds. I also bumped Python to 3.10, since that's now released and works fine.