### PR TITLE
kv for legacy rain behavior

### DIFF
--- a/fgd/brush/func/func_precipitation.fgd
+++ b/fgd/brush/func/func_precipitation.fgd
@@ -22,6 +22,8 @@
 	innerfarparticle(particlesystem) : "Inner far system" : "" : "Name of the inner far particle system. If not set, this will be automatically selected from the precipitation type keyvalue."
 	outerparticle(particlesystem) : "Outer system" : "" : "Name of the outer particle system. If not set, this will be automatically selected from the precipitation type keyvalue."
 
+	legacybehavior(boolean) : "Legacy Rain Behavior" : 0 : "Enables old, broken behavior of rain, where rain occurs in the center of map with no Z-culling. Most older (pre-Chaos) maps get around this by using func_precipitation_blockers. Defaults to true if not present. Only applies to the 'Rain' Precipitation Type."
+
 	input Alpha(integer) : "Changes the density of the rain, " +
 	"and may add additional particle effects like fog or leaves. " +
 	"Accepts inputs from -1 to 255."


### PR DESCRIPTION
Tackles https://github.com/momentum-mod/game/issues/1695

If this kv is not present, it defaults to `true` in code so older maps that rely on broken behavior (eg. `bhop_arcane`) work still.

Will be off for new maps now by including this kv and defaulting it to `false`. Will want to flip it to `true` in momentum's map porting though.

To summarize, legacy behavior rains at the center of the map, extending outward by how large the `func_precipitation` brush is. It also has no Z-culling. Definitely keep this off if you want rain to function around the actual brush.