### PR TITLE
Add cmdseqs for portal traversal lighting

### DIFF
--- a/hammer/cfg_momentum/CmdSeqDefault.wc
+++ b/hammer/cfg_momentum/CmdSeqDefault.wc
@@ -189,4 +189,186 @@
             "no_wait" "1" // All game_exe things apparently have no wait, but it isn't used so whatever
         }
     }
+    "HDR Portal Lighting Full Compile"
+    {
+        "1"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "zonmaker.exe"
+            "params" "$path\$file.vmf"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "2"
+        {
+            "enabled" "1"
+            "special_cmd" "261" // Copy File if it exists
+            "run" ""
+            "params" "$path\$file.zon $bspdir\..\zones\$file.zon"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "3"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$bsp_exe"
+            "params" "-game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "4"
+        {
+            "enabled" "0"
+            "special_cmd" "0"
+            "run" "$postcompiler_exe"
+            "params" "--propcombine $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "5"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$vis_exe"
+            "params" "-game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "6"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$light_exe"
+            "params" "-hdr -StaticPropLighting -StaticPropPolys -PortalTraversalLighting -game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "7"
+        {
+            "enabled" "1"
+            "special_cmd" "257" // Copy File
+            "run" ""
+            "params" "$path\$file.bsp $bspdir\$file.bsp"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "8"
+        {
+            "enabled" "0"
+            "special_cmd" "0"
+            "run" "$game_exe"
+            "params" "-dev -console -allowdebug -game $gamedir +map $file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "1" // All game_exe things apparently have no wait, but it isn't used so whatever
+        }
+    }
+    "HDR Portal Lighting+AO Full Compile"
+    {
+        "1"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "zonmaker.exe"
+            "params" "$path\$file.vmf"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "2"
+        {
+            "enabled" "1"
+            "special_cmd" "261" // Copy File if it exists
+            "run" ""
+            "params" "$path\$file.zon $bspdir\..\zones\$file.zon"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "3"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$bsp_exe"
+            "params" "-game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "4"
+        {
+            "enabled" "0"
+            "special_cmd" "0"
+            "run" "$postcompiler_exe"
+            "params" "--propcombine $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "5"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$vis_exe"
+            "params" "-game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "6"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$light_exe"
+            "params" "-hdr -StaticPropLighting -StaticPropPolys -PortalTraversalLighting -PortalTraversalAO -game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "7"
+        {
+            "enabled" "1"
+            "special_cmd" "257" // Copy File
+            "run" ""
+            "params" "$path\$file.bsp $bspdir\$file.bsp"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "8"
+        {
+            "enabled" "0"
+            "special_cmd" "0"
+            "run" "$game_exe"
+            "params" "-dev -console -allowdebug -game $gamedir +map $file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "1" // All game_exe things apparently have no wait, but it isn't used so whatever
+        }
+    }
 }

--- a/hammer/cfg_momentum/CmdSeqDefault.wc
+++ b/hammer/cfg_momentum/CmdSeqDefault.wc
@@ -7,6 +7,31 @@
     // 259 - Rename File
     // 261 - Copy File if it exists
     // And they have no "run" string
+    "Zonmaker Only"
+    {
+        "1"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "zonmaker.exe"
+            "params" "$path\$file.vmf"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "2"
+        {
+            "enabled" "1"
+            "special_cmd" "261" // Copy File if it exists
+            "run" ""
+            "params" "$path\$file.zon $bspdir\..\zones\$file.zon"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+    }
     "Fast"
     {
         "1"

--- a/hammer/cfg_p2ce/CmdSeqDefault.wc
+++ b/hammer/cfg_p2ce/CmdSeqDefault.wc
@@ -145,4 +145,142 @@
             "no_wait" "1" // All game_exe things apparently have no wait, but it isn't used so whatever
         }
     }
+    "HDR Portal Lighting Full Compile"
+    {
+        "1"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$bsp_exe"
+            "params" "-game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "2"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$postcompiler_exe"
+            "params" "--propcombine $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "3"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$vis_exe"
+            "params" "-game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "4"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$light_exe"
+            "params" "-hdr -StaticPropLighting -StaticPropPolys -PortalTraversalLighting -game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "5"
+        {
+            "enabled" "1"
+            "special_cmd" "257" // Copy File
+            "run" ""
+            "params" "$path\$file.bsp $bspdir\$file.bsp"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "6"
+        {
+            "enabled" "0"
+            "special_cmd" "0"
+            "run" "$game_exe"
+            "params" "-dev -console -allowdebug -game $gamedir +map $file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "1" // All game_exe things apparently have no wait, but it isn't used so whatever
+        }
+    }
+    "HDR Portal Lighting+AO Full Compile"
+    {
+        "1"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$bsp_exe"
+            "params" "-game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "2"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$postcompiler_exe"
+            "params" "--propcombine $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" ""
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "3"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$vis_exe"
+            "params" "-game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "4"
+        {
+            "enabled" "1"
+            "special_cmd" "0"
+            "run" "$light_exe"
+            "params" "-hdr -StaticPropLighting -StaticPropPolys -PortalTraversalLighting -PortalTraversalAO -game $gamedir $path\$file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "5"
+        {
+            "enabled" "1"
+            "special_cmd" "257" // Copy File
+            "run" ""
+            "params" "$path\$file.bsp $bspdir\$file.bsp"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "0"
+        }
+        "6"
+        {
+            "enabled" "0"
+            "special_cmd" "0"
+            "run" "$game_exe"
+            "params" "-dev -console -allowdebug -game $gamedir +map $file"
+            "ensure_check" "0"
+            "ensure_fn" "" 
+            "use_process_wnd" "1"
+            "no_wait" "1" // All game_exe things apparently have no wait, but it isn't used so whatever
+        }
+    }
 }


### PR DESCRIPTION
Portal traversal lighting is so damn cool that these deserve their own compile setups.

They are straight copies of "HDR Full Compile" but with the portal traversal lighting options for vrad.