### PR TITLE
Fix logic_compare

### DIFF
--- a/fgd/point/logic/logic_case.fgd
+++ b/fgd/point/logic/logic_case.fgd
@@ -50,6 +50,6 @@
 	output OnCase14(void) : "Fired when the input value equals the Case14 value."
 	output OnCase15(void) : "Fired when the input value equals the Case15 value."
 	output OnCase16(void) : "Fired when the input value equals the Case16 value."
-	output OnDefault[engine](string) : "Fired when the input value does not equal any of the Case values. Passes the input value."
+	output OnDefault(string) : "Fired when the input value does not equal any of the Case values. Passes the input value."
 	output OnUsed(string) : "Fired when an input value is received, regardless of whether it matches a case. Passes the input value."
 	]

--- a/fgd/point/logic/logic_compare.fgd
+++ b/fgd/point/logic/logic_compare.fgd
@@ -1,28 +1,24 @@
-@PointClass base(BaseEntityPoint) 
-	iconsprite("editor/logic_compare.vmt") 
-	color(0 100 250) 
+@PointClass base(BaseEntityPoint)
+	iconsprite("editor/logic_compare.vmt")
+	color(0 100 250)
 = logic_compare: "Compares an input value to another value. " +
 	"If the input value is less than the compare value, the OnLessThan output is fired with the input value. " +
 	"If the input value is equal to the compare value, the OnEqualTo output is fired with the input value. " +
 	"If the input value is greater than the compare value, the OnGreaterThan output is fired with the input value."
 	[
-	initialvalue[engine](string) : "Initial value" : : "Initial value for the input value."
-	comparevalue[engine](string) : "Compare value" : : "The value to compare against."
+	initialvalue(string) : "Initial value" : : "Initial value for the input value."
+	comparevalue(string) : "Compare value" : : "The value to compare against."
 
 	input Compare(void) : "Force a compare of the input value with the compare value."
-
-	input SetValue[engine](string) : "Set the value that will be compared against the compare value."
-	input SetValueCompare[engine](string) : "Set the value that will be compared against the compare value and performs the comparison."
-	input SetCompareValue[engine](string) : "Set the compare value."
-
-	output OnLessThan[engine](string) : "Fired when the input value is less than the compare value. Sends the input value as data."
-	output OnEqualTo[engine](string) : "Fired when the input value is equal to the compare value. Sends the input value as data."
-	output OnNotEqualTo[engine](string) : "Fired when the input value is different from the compare value. Sends the input value as data."
-	output OnGreaterThan[engine](string) : "Fired when the input value is greater than the compare value. Sends the input value as data."
-
-
-	// Extra values
+	input SetValue(string) : "Set the value that will be compared against the compare value."
+	input SetValueCompare(string) : "Set the value that will be compared against the compare value and performs the comparison."
+	input SetCompareValue(string) : "Set the compare value."
 	input SetCompareValueCompare(string) : "Sets the compare value and performs the comparison."
+
+	output OnLessThan(string) : "Fired when the input value is less than the compare value. Sends the input value as data."
+	output OnEqualTo(string) : "Fired when the input value is equal to the compare value. Sends the input value as data."
+	output OnNotEqualTo(string) : "Fired when the input value is different from the compare value. Sends the input value as data."
+	output OnGreaterThan(string) : "Fired when the input value is greater than the compare value. Sends the input value as data."
 	output OnGreaterThanOrEqualTo(string) : "Fired when the input value is greater than or equal to the compare value. Sends the input value as data."
 	output OnLessThanOrEqualTo(string) : "Fired when the input value is greater than or equal to the compare value. Sends the input value as data."
 	]

--- a/fgd/point/logic/logic_compare.fgd
+++ b/fgd/point/logic/logic_compare.fgd
@@ -8,6 +8,7 @@
 	[
 	initialvalue(string) : "Initial value" : : "Initial value for the input value."
 	comparevalue(string) : "Compare value" : : "The value to compare against."
+	strlenallowed(boolean) : "Use string length" : 0 : "Use the length of the string in the compare value rather than its actual value."
 
 	input Compare(void) : "Force a compare of the input value with the compare value."
 	input SetValue(string) : "Set the value that will be compared against the compare value."

--- a/fgd/point/logic/logic_multicompare.fgd
+++ b/fgd/point/logic/logic_multicompare.fgd
@@ -6,6 +6,7 @@
 	[
 	integervalue(integer) : "Integer Value (optional)" : : "The value all inputs are compared to if ''Should use Reference Value'' is enabled."
 	ShouldComparetoValue(boolean) : "Should use Integer Value" : 0 : "If enabled, all inputs are compared to the reference value. If not enabled, they are instead compared to the last input added."
+	strlenallowed(boolean) : "Use string length" : 0 : "Use the length of the string in the compare value rather than its actual value."
 
 	// Inputs
 	input InputValue(integer) : "Adds a value to our set of inputs and fires CompareValues automatically, " +


### PR DESCRIPTION
Spen was smart and added MBase & engine tags to these kvs, since (I assume) mbase was just exposing some things that already existed in game.

When we removed mbase tags here, engine wasnt also removed. We have this from mbase though!

Also exposes `strlenallowed` field which uses the length of the string of the compare value rather than its actual value. Seems a little useless (imo) but it exists in the game so lets be consistent.