### PR TITLE
Add Momentum's func_slide

### DIFF
--- a/fgd/brush/func/func_slide.fgd
+++ b/fgd/brush/func/func_slide.fgd
@@ -1,0 +1,9 @@
+@SolidClass base(func_brush)
+	appliesto(MOMENTUM)
+= func_slide: "A brush entity the player will slide on like a surf ramp, even at shallow angles. Ducking and unducking while sliding work the same as when on normal ground."
+	[
+	linedivider_slide(string) readonly : "----------------------------------------------------------------------------------------------------------"
+	stayonslide(boolean) : "Keep player on slide surface" : 0 : "Keep the player attached to the slide surface (for example, when sliding down ground of increasing steepness)."
+	allowjump(boolean) : "Allow jumping" : 1 : "Allow the player to jump while sliding. The player is still required to be on a surface that is not too steep to stand on in order to jump."
+	disablegravity(boolean) : "Disable gravity" : 0 : "Disable gravity while sliding."
+	]

--- a/fgd/visgroups.cfg
+++ b/fgd/visgroups.cfg
@@ -237,6 +237,7 @@
 			* `func_wall`
 			* `func_wall_toggle`
 			* `func_momentum_brush`
+		- Slides (`func_slide`)
 		- LOD Brushes (`func_lod`)
 		- Conveyors
 			* `func_conveyor`


### PR DESCRIPTION
This adds the entity definition for `func_slide`, which should eventually replace `trigger_momentum_slide`.

Since slide trigger entities will need to be replaced with new entities anyway, I've taken the opportunity to rename some entity keys and clean up their descriptions.

The keys function the same as on the old entity, plus the "Keep player on slide surface" option is no longer mutually exclusive with being able to jump thanks to the new implementation.