### PR TITLE
Fix effect brushes

### DIFF
--- a/fgd/bases/BaseDustParticleSpawner.fgd
+++ b/fgd/bases/BaseDustParticleSpawner.fgd
@@ -1,12 +1,7 @@
-@BaseClass 
+@BaseClass base(BaseEffectBrush)
 	sphere(distmax)
 = BaseDustParticleSpawner
 	[
-	targetname(target_source) : "Name" : : "The name that other entities refer to this entity by."
-
-	vscripts[VSCRIPT](scriptlist) : "Entity Scripts" : : "Name(s) of script files that are executed after all entities have spawned."
-	thinkfunction[VSCRIPT](string) : "Script think function" : : "Name of a function in this entity's script scope which will be called automatically."
-
 	startdisabled(boolean) : "Start Disabled" : 0
 	color(color255) : "Particle Color (R G B)" : "255 255 255"
 	spawnrate(integer) : "Particle Per Second" : 40 : "Number of particles to spawn, per second."
@@ -17,6 +12,8 @@
 	distmax(integer) : "Maximum Visible Distance" : 1024 : "Maximum distance at which particles are visible. They fade to translucent at this distance."
 	frozen(boolean) : "Frozen" : 0 : "When set, this entity spawns the number of particles in SpawnRate immediately, and then goes inactive."
 	affectedbywind(boolean) : "Affected by Wind" : 1 : "When set, the dust will be affected by any env_wind entity settings in the map."
+
+	linedivider_base[!engine](string) readonly : "----------------------------------------------------------------------------------------------------------" : ""
 
 	// Inputs
 	input TurnOn(void) : "Turn on."

--- a/fgd/bases/BaseEffectBrush.fgd
+++ b/fgd/bases/BaseEffectBrush.fgd
@@ -1,0 +1,16 @@
+@BaseClass = BaseEffectBrush
+	[
+	targetname(target_source) : "Name" : : "The name that other entities refer to this entity by."
+	globalname(string) : "Global Entity Name" : : "Name by which this entity is linked to another entity in a different map. " +
+		"When the player transitions to a new map, entities in the new map with globalnames matching entities in the previous map " +
+		"will have the previous map's state copied over their state."
+
+	parentname[!srctools](target_destination) : "Parent" : : "The name of this entity's parent in the movement hierarchy. Entities with parents move with their parent. Set an attachment point via 'parentname,attachment'."
+	parentname[srctools](target_destination) : "Parent" : : "The name of this entity's parent in the movement hierarchy. Entities with parents move with their parent."
+	parent_attachment_point[srctools](string) : "Attachment Point" : : "If set, attach to this attachment point on the parent during spawn."
+
+	vscripts[VSCRIPT](scriptlist) : "Entity Scripts" : : "Name(s) of script files that are executed after all entities have spawned."
+	thinkfunction[VSCRIPT](string) : "Script think function" : : "Name of a function in this entity's script scope which will be called automatically."
+
+	linedivider_base[!engine](string) readonly : "----------------------------------------------------------------------------------------------------------" : ""
+	]

--- a/fgd/brush/env/env_bubbles.fgd
+++ b/fgd/brush/env/env_bubbles.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityBrush) 
+@SolidClass base(BaseEffectBrush) 
 	color(200 200 0)
 = env_bubbles: "An entity used to create a volume in which to spawn bubbles."
 	[

--- a/fgd/brush/env/env_embers.fgd
+++ b/fgd/brush/env/env_embers.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityBrush) 
+@SolidClass base(BaseEffectBrush) 
 	color(200 200 0)
 = env_embers: "An entity used to create a volume in which to spawn fire embers."
 	[
@@ -19,5 +19,4 @@
 		1: "Start On" : 0
 		2: "Toggle" : 0
 		]
-
 	]

--- a/fgd/brush/env/env_embers.fgd
+++ b/fgd/brush/env/env_embers.fgd
@@ -2,6 +2,11 @@
 	color(200 200 0)
 = env_embers: "An entity used to create a volume in which to spawn fire embers."
 	[
+	angles(angle) : "Pitch Yaw Roll (X Y Z)" : "0 0 0" : "This entity's orientation in the world. " +
+		"Roll is the rotation around the X axis, " +
+		"pitch is rotation around the Y axis and " +
+		"yaw is the rotation around the Z axis."
+
 	particletype[engine](integer) : "Ember type" : 0
 	particletype(choices) : "Ember type" : 0 =
 		[

--- a/fgd/brush/func/func_precipitation.fgd
+++ b/fgd/brush/func/func_precipitation.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityBrush) 
+@SolidClass base(BaseEffectBrush) 
 = func_precipitation: "A brush entity that creates rain and snow inside its volume."
 	[
 	renderamt(integer) : "Density (0-100%)" : 5 : "This is the amount of particles that fall down from top side of brush. " +

--- a/fgd/brush/func/func_smokevolume.fgd
+++ b/fgd/brush/func/func_smokevolume.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityBrush) 
+@SolidClass base(BaseEffectBrush) 
 = func_smokevolume: "A brush entity that spawns smoke particles within its volume."
 	[
 	spawnflags(flags)  =


### PR DESCRIPTION
Closes https://github.com/momentum-mod/game/issues/1789

This fixes bugs with brush-based effect entities having their effects appear at the origin of the map. These entities use the collision bounds of the brush, assuming it is in world space. However, including the `origin` KV on a brush causes the model bounds to be defined in local space. Using local space info as if it was worldspace ended up in the code spawning effects at the origin of the map.

Fixed by creating a base that covers what these entities were doing in older FGDs where they actually worked (which omits `origin` KV).

--------------------

TLDR: `origin` KV on these ents breaks them so make sure it is removed. Older FGDs & thus maps dont have the KV so they work fine.