### PR TITLE
feat: Allow various Portal entities to have their models changed

### DIFF
--- a/fgd/point/npc/npc_rocket_turret.fgd
+++ b/fgd/point/npc/npc_rocket_turret.fgd
@@ -14,7 +14,7 @@
 	rocketlifetime(float) : "Rocket Lifetime" : 20 : "The rocket will automatically detonate after this number of seconds."
 	TripwireMode(boolean) : "Tripwire Mode" : 0 : "Makes the turret aim in a specific direction instead of following the target. When the beam is crossed, a rocket instantly fires."
 	TripwireAimTarget(target_destination) : "Tripwire Aim Target" : : "In tripwire mode, the entity to aim at."
-	model(studio) : "[H] Model" : "models/props_bts/rocket_sentry.mdl" : "Model to display in Hammer. Use Init Code and a comp_precache_model to change the model in-game."
+	model(studio) : "Model" : "models/props_bts/rocket_sentry.mdl" : "Model to use in-game"
 
 	// Inputs
 	input Toggle(void) : "Toggles between activated and deactivated states."

--- a/fgd/point/npc/npc_security_camera.fgd
+++ b/fgd/point/npc/npc_security_camera.fgd
@@ -1,6 +1,6 @@
 @PointClass base(BaseNPC, SetSkin)
 	appliesto(P2CE)
-	studioprop("models/props/security_camera.mdl")
+	studioprop()
 = npc_security_camera: "Aperture Science Security Camera. " +
 		"Follows either the player or their pings (Portal 2). " +
 		"When a portal is opened behind it it will fall off the wall. " + 
@@ -33,6 +33,8 @@
 		2: "P-Body"
 		3: "ATLAS"
 		]
+
+	model(studio) : "Camera Model" : "models/props/security_camera.mdl" : "Model to be used in game"
 
 	// Inputs
 	input Enable(void) : "Start following players."

--- a/fgd/point/prop/prop_button.fgd
+++ b/fgd/point/prop/prop_button.fgd
@@ -10,5 +10,5 @@
 		0: "Clean"
 		1: "Dirty"
 		]
-	model(studio) : "[H] Model" : "models/props/switch001.mdl" : "Model to display in Hammer. Use Init Code and a comp_precache_model to change the model in-game."
+	model(studio) : "Model" : "models/props/switch001.mdl" : "Model to use in game."
 	]

--- a/fgd/point/prop/prop_floor_ball_button.fgd
+++ b/fgd/point/prop/prop_floor_ball_button.fgd
@@ -3,5 +3,5 @@
 	studioprop() 
 = prop_floor_ball_button: "A floor button which is only activated by a Sphere-type prop_weighted_cube."
 	[
-		model(studio) : "[H] Model" : "models/props/ball_button.mdl" : "Model to display in Hammer. Use Init Code and a comp_precache_model to change the model in-game."
+		model(studio) : "Model" : "models/props/ball_button.mdl" : "Model to be used in game"
 	]

--- a/fgd/point/prop/prop_floor_cube_button.fgd
+++ b/fgd/point/prop/prop_floor_cube_button.fgd
@@ -3,6 +3,6 @@
 	studioprop() 
 = prop_floor_cube_button: "A floor button which is activated by a prop_weighted_cube."
 	[
-	model(studio) : "[H]] Model" : "models/props/box_socket.mdl" : "Model to display in Hammer. Use Init Code and a comp_precache_model to change the model in-game."
+	model(studio) : "Button model" : "models/props/box_socket.mdl" : "Model to be used in game"
 	acceptsball(boolean) : "Accepts Balls" : 0 : "Do Edgeless Safety Cubes activate this? Should almost always be No unless no balls are in the map."
 	]

--- a/fgd/point/prop/prop_glados_core.fgd
+++ b/fgd/point/prop/prop_glados_core.fgd
@@ -1,9 +1,10 @@
 @PointClass base(BasePropPhysics)
-	studioprop("models/props_bts/glados_ball_reference.mdl")
+	studioprop()
 	appliesto(P2CE)
 = prop_glados_core: "The P1 personality cores for GlaDOS. Resemble little eyeballs with handles. " +
 	"These play lines and look around when near the player. "
 	[
+
 	coretype[engine](integer) : "Core Personality" : 1
 	coretype(choices) : "Core Personality" : 1 : "Which personality VO set the core is set to." =
 		[
@@ -14,6 +15,8 @@
 		]
 
 	delaybetweenlines(float) : "Pause (in secs) between VO Lines." : 0.4 : "When the core is talking, this is the number of seconds delay between it's spoken lines."
+
+	model(studio) : "Model" : "models/props_bts/glados_ball_reference.mdl" : "Model to use in game."
 
 	// Inputs
 	input Panic(void) : "Core is near death, panic."

--- a/fgd/point/prop/prop_glados_core.fgd
+++ b/fgd/point/prop/prop_glados_core.fgd
@@ -1,5 +1,5 @@
 @PointClass base(BasePropPhysics)
-	studioprop("models/npcs/personality_sphere/personality_sphere.mdl")
+	studioprop("models/props_bts/glados_ball_reference.mdl")
 	appliesto(P2CE)
 = prop_glados_core: "The P1 personality cores for GlaDOS. Resemble little eyeballs with handles. " +
 	"These play lines and look around when near the player. "

--- a/fgd/point/prop/prop_linked_portal_door.fgd
+++ b/fgd/point/prop/prop_linked_portal_door.fgd
@@ -1,12 +1,14 @@
 @PointClass base(BaseEntityAnimating, LinkedPortalDoor) 
 	appliesto(+USE_PORTALS, P2CE) 
-	studioprop("models/props/portal_door.mdl") 
+	studioprop() 
 	line(255 255 0, targetname, lightingorigin) 
 = prop_linked_portal_door: "A door which is linked by a portal to another 'prop_linked_portal_door' entity. " +
 	"This is premade at the correct size to allow portaling though the included door. It appears as a grey door."
 	[
 	partnername(target_destination) : "Linked Partner" : : "Another 'prop_linked_portal_door' entity which will link to this one."
 	lightingorigin(target_destination) : "Lighting Origin" : : "Select an info_lighting to specify a location to sample lighting from for the door."
+
+	model(studio) : "Model" : "models/props/portal_door.mdl" : "Model to use in-game"
 
 	// Outputs
 	output OnFullyOpen(void) : "Called when the door has finished its open animation."

--- a/fgd/point/prop/prop_under_button.fgd
+++ b/fgd/point/prop/prop_under_button.fgd
@@ -1,8 +1,9 @@
 @PointClass base(BasePedButton) 
 	appliesto(P2CE)
-	studioprop("models/props_underground/underground_testchamber_button.mdl") 
+	studioprop() 
 = prop_under_button: "A button which is activated by player use or by game inputs, for use in underground test chambers. " +
 	"Uses different press/release sounds compared to the modern one. " +
 	"The same tick-tock noise is used to indicate limited time."
 	[
+	model(studio) : "Model" : "models/props_underground/underground_testchamber_button.mdl" : "Model to use in game."
 	]

--- a/fgd/point/prop/prop_under_floor_button.fgd
+++ b/fgd/point/prop/prop_under_floor_button.fgd
@@ -1,9 +1,11 @@
 @PointClass base(BasePortButton) 
 	appliesto(P2CE)
-	studioprop("models/props_underground/underground_floor_button.mdl") 
+	studioprop() 
 = prop_under_floor_button: "A floor button which is activated by a player or objects, for use in the underground test chambers. " +
 	"It plays different sounds, and has a larger trigger area."
 	[
+
+	model(studio) : "Button model" : "models/props_underground/underground_floor_button.mdl" : "The model to be used in game"
 
 	// Outputs
 	output OnPressedBlue(void) : "Called in Coop when the button has been pressed by ATLAS."


### PR DESCRIPTION
Don't merge till red pr is merged.

Doesn't add the following.
- prop_testchamber_door
- prop_tractor_beam
- prop_wall_projector
- prop_monster_box
- npc_personality_core
- prop_glass_futbol