### PR TITLE
Remove redundant spawnflag numbers on math_vector

### DIFF
--- a/fgd/point/math/math_vector.fgd
+++ b/fgd/point/math/math_vector.fgd
@@ -8,9 +8,9 @@
 	
 	spawnflags(flags) =
 		[
-		1 : "[1] Disable X" : 0
-		2 : "[2] Disable Y" : 0
-		4 : "[4] Disable Z" : 0
+		1 : "Disable X" : 0
+		2 : "Disable Y" : 0
+		4 : "Disable Z" : 0
 		]
 
 	// Inputs


### PR DESCRIPTION
When FGD is compiled, it adds corresponding numbers to every single spawnflag. So for `math_vector` it would compile to having duplicate numbers. Eg:
![image](https://user-images.githubusercontent.com/9014762/176883885-cdf09799-3894-4aaf-b6e9-083f5a54ef05.png)
