### PR TITLE
Put static_prop in appliesto(engine)

### DIFF
--- a/fgd/engine/static_prop.fgd
+++ b/fgd/engine/static_prop.fgd
@@ -1,5 +1,6 @@
 @PointClass base(prop_static) 
-	appliesto(!engine)
+	appliesto(engine)
 = static_prop: "Alternate name for prop_static."
 	[
 	]
+	


### PR DESCRIPTION
It's a rename of prop_static, but other prop types do not have this type of rename, potentially confusing the mapper.

It's not in visgroups or in either of the factories
