### PR TITLE
Remove projected texture volumetric settings

### DIFF
--- a/fgd/point/env/env_projectedtexture.fgd
+++ b/fgd/point/env/env_projectedtexture.fgd
@@ -48,8 +48,9 @@
 		"The material browser is only available here to assist with finding textures since materials typically have the same name as their textures."
 	textureframe(integer) : "Texture Frame" : 0 : "If the VTF is multi-frame, specify the frame to use."
 
-	volumetric(boolean) : "Enable Volumetrics" : 0 : "Enables/disables volumetrics from this projected texture."
-	volumetricintensity(float) : "Volumetric Intensity" : "1.0" : "Sets the intensity of the volumetric lighting."
+	// Re-enable these when volumetrics are brought back
+	// volumetric(boolean) : "Enable Volumetrics" : 0 : "Enables/disables volumetrics from this projected texture."
+	// volumetricintensity(float) : "Volumetric Intensity" : "1.0" : "Sets the intensity of the volumetric lighting."
 	
 	style[engine](integer) : "Appearance" : 0
 	style(choices) : "Appearance" : "0" =
@@ -102,8 +103,9 @@
 	// not implemented
 	//input Ambient(float) : "Set ambient light amount"
 	
-	input EnableVolumetrics(boolean) : "Set if the volumetrics are enabled."
-	input SetVolumetricIntensity(float) : "Sets the volumetric lighting's intensity."
+	// Re-enable these when volumetrics are brought back
+	// input EnableVolumetrics(boolean) : "Set if the volumetrics are enabled."
+	// input SetVolumetricIntensity(float) : "Sets the volumetric lighting's intensity."
 
 	input SetBrightnessScale(float) : "Sets the brightness."
 	]


### PR DESCRIPTION
This removes the projected texture volumetric settings by commenting them out in the FGD. Volumetrics are currently not functional, so this will avoid confused users turning them on and wondering why it doesn't do anything or produces broken results