### PR TITLE
fix: Add disableshadowdepth KV to static props

### DIFF
--- a/fgd/point/prop/prop_static.fgd
+++ b/fgd/point/prop/prop_static.fgd
@@ -94,6 +94,7 @@
 	linedivider_light[!engine](string) readonly : "----------------------------------------------------------------------------------------------------------" : ""
 
 	disableshadows(boolean) : "Disable Shadows" : 0
+	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."
 	disablevertexlighting(boolean) : "Disable Vertex lighting" : 0 : "Disable per-vertex lighting on this prop."
 	disableselfshadowing(boolean) : "Disable Self-Shadowing" : 0 : "When vertex lighting is enabled, prevent the geometry from self-shadowing -- casting shadows onto itself."
 	ignorenormals(boolean) : "Ignore Surface Normal" : 0 : "When vertex lighting is enabled, ignore the surface normal of faces when calculating the vertex lighting. Useful for thin, translucent objects such as leaves on foliage props."


### PR DESCRIPTION
Previously, the `disableshadowdepth` KV was missing which led to confusion about how to disable clustered shadows for static props ([engine#1435](https://github.com/StrataSource/Engine/issues/1485)). This seems to be caused by `prop_static` not using `BaseEntityAnimating` as a base, for various reasons, so I've added the KV directly to `prop_static` to match the other shadow-related KVs.