### PR TITLE
feat: Add 'Always Update' flag to RT light entities

### DIFF
--- a/fgd/bases/BaseClusteredDynLight.fgd
+++ b/fgd/bases/BaseClusteredDynLight.fgd
@@ -1,5 +1,11 @@
 @BaseClass base(BaseClusteredLight) = BaseClusteredDynLight
 	[
+	spawnflags(flags)  =
+		[
+		1: "Initially dark" : 0
+		2: "Shadowed" : 0
+		4: "Always Update": 0
+		]
 	_lightmode(choices) : "Light mode" : 2 = 
 		[
 		0: "Static"


### PR DESCRIPTION
Will allow a workaround for e.g. dynamic props where the shadow doesn't automatically update.

Of course ideally we should account for these cases but if someone expects the light to be updating every frame (when visible) regardless this is a good workaround when it doesn't (and this will happen a lot)