### PR TITLE
feat: Add light cookie fields/inputs to light_rt entities

### DIFF
--- a/fgd/bases/BaseClusteredDynLight.fgd
+++ b/fgd/bases/BaseClusteredDynLight.fgd
@@ -13,4 +13,10 @@
 		2: "Static Bounce"
 		3: "Fully Dynamic"
 		]
+		
+	texturename(string) : "Cookie Texture Name" : "" : "The cookie texture to use for the light. An empty value means no cookie texture."
+	textureframe(integer) : "Cookie Texture Frame" : 0 : "The frame of the cookie texture to use for the light."
+	
+	input SetCookieTexture(string) : "Set the cookie texture of this light. An empty value means no cookie texture."
+	input SetCookieTextureFrame(integer) : "Set the frame texture of the cookie texture for this light."
 	]


### PR DESCRIPTION
Allows cookie textures to be used on regular light_rt entities