### PR TITLE
Remove almost every single slavery reference from FGD

### DIFF
--- a/fgd/bases/BaseTank.fgd
+++ b/fgd/bases/BaseTank.fgd
@@ -19,8 +19,6 @@
 		]
 
 	control_volume(target_destination) : "Control Volume" : : "Name of a trigger the specifies the volume in which a player must be to control this tank."
-	
-	master(string) : "(Team) Master"
 
 	yawrate(string) : "Yaw rate" : "30" : "How fast tank can look left or right."
 	yawrange(string) : "Yaw range" : "180" : "How far tank can turn left or right."

--- a/fgd/bases/Door.fgd
+++ b/fgd/bases/Door.fgd
@@ -1,4 +1,4 @@
-@BaseClass base(BaseEntityVisBrush, MasterEnt) 
+@BaseClass base(BaseEntityVisBrush) 
 	line(255 255 255, targetname, chainstodoor)
 = Door
 	[

--- a/fgd/bases/MasterEnt.fgd
+++ b/fgd/bases/MasterEnt.fgd
@@ -1,6 +1,0 @@
-@BaseClass 
-	line(255 255 255, targetname, master) 
-= MasterEnt
-	[
-	master(target_destination) : "Master (Obsolete)" : : "(Legacy) The name of a master entity. If the master hasn't been activated, this entity will not activate."
-	]

--- a/fgd/brush/func/func_rot_button.fgd
+++ b/fgd/brush/func/func_rot_button.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityVisBrush, MasterEnt, Button) 
+@SolidClass base(BaseEntityVisBrush, Button) 
  = func_rot_button: "A brush entity that's designed to be used for a rotating player-useable button. When used by the player, it rotates to a pressed position."
 	[
 	speed(integer) : "Speed" : 50 : "The speed that the button rotates, in degrees per second."

--- a/fgd/brush/momentary_rot_button.fgd
+++ b/fgd/brush/momentary_rot_button.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(BaseEntityVisBrush, Angles, MasterEnt)
+@SolidClass base(BaseEntityVisBrush, Angles)
 = momentary_rot_button: "A brush entity that's designed to be used for rotating wheels, " +
 	"where the player can rotate them to arbitrary positions before stopping."
 	[

--- a/fgd/brush/trigger/trigger_hurt.fgd
+++ b/fgd/brush/trigger/trigger_hurt.fgd
@@ -1,4 +1,4 @@
-@SolidClass base(Trigger, MasterEnt, DamageType) 
+@SolidClass base(Trigger, DamageType) 
 = trigger_hurt: "A trigger volume that damages entities that touch it."
 	[
 	damage(integer) : "Damage" : 20 : "The amount of damage done to entities that touch this trigger. " +

--- a/fgd/point/env/env_fog_controller.fgd
+++ b/fgd/point/env/env_fog_controller.fgd
@@ -19,7 +19,7 @@
 	farz(string) : "Far Z Clip Plane" : "-1" : "The distance at which the world will not be rendered."
 	spawnflags(flags) : "spawnflags" =
 		[
-			1: "Default Fog Controller" : 0
+			1: "Primary Fog Controller" : 0
 		]
 
 	hdrcolorscale(float) : "HDR Color Scale" : "1" : "Float value to multiply fog color by when running in HDR mode."

--- a/fgd/point/env/env_fog_controller.fgd
+++ b/fgd/point/env/env_fog_controller.fgd
@@ -19,7 +19,7 @@
 	farz(string) : "Far Z Clip Plane" : "-1" : "The distance at which the world will not be rendered."
 	spawnflags(flags) : "spawnflags" =
 		[
-			1: "Primary Fog Controller" : 0
+			1: "Primary Fog Controller (takes priority over existing controllers)" : 0
 		]
 
 	hdrcolorscale(float) : "HDR Color Scale" : "1" : "Float value to multiply fog color by when running in HDR mode."

--- a/fgd/point/env/env_fog_controller.fgd
+++ b/fgd/point/env/env_fog_controller.fgd
@@ -19,7 +19,7 @@
 	farz(string) : "Far Z Clip Plane" : "-1" : "The distance at which the world will not be rendered."
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Master (Has priority if multiple env_fog_controllers exist)" : 0
+			1: "Default Fog Controller" : 0
 		]
 
 	hdrcolorscale(float) : "HDR Color Scale" : "1" : "Float value to multiply fog color by when running in HDR mode."

--- a/fgd/point/env/env_tonemap_controller.fgd
+++ b/fgd/point/env/env_tonemap_controller.fgd
@@ -5,7 +5,7 @@
 	[
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Master (Has priority if multiple env_tonemap_controllers exist)" : 0
+		1: "Default Tonemapper" : 0
 		]
 
 	// Inputs

--- a/fgd/point/env/env_tonemap_controller.fgd
+++ b/fgd/point/env/env_tonemap_controller.fgd
@@ -5,7 +5,7 @@
 	[
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Primary Tonemapper" : 0
+		1: "Primary Tonemapper (takes priority over existing controllers)" : 0
 		]
 
 	// Inputs

--- a/fgd/point/env/env_tonemap_controller.fgd
+++ b/fgd/point/env/env_tonemap_controller.fgd
@@ -5,7 +5,7 @@
 	[
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Default Tonemapper" : 0
+		1: "Primary Tonemapper" : 0
 		]
 
 	// Inputs

--- a/fgd/point/game/game_end.fgd
+++ b/fgd/point/game/game_end.fgd
@@ -1,4 +1,4 @@
-@PointClass base(BaseEntityPoint, MasterEnt)
+@PointClass base(BaseEntityPoint)
 	appliesto(+USE_MULTIPLAYER)
 	iconsprite("editor/game_end.vmt")
 = game_end: "An entity that ends a multiplayer game."

--- a/fgd/point/game/game_player_equip.fgd
+++ b/fgd/point/game/game_player_equip.fgd
@@ -1,5 +1,5 @@
 @PointClass appliesto(-MOMENTUM)
-	base(BaseEntityPoint, MasterEnt)
+	base(BaseEntityPoint)
 	iconsprite("editor/ficool2/game_player_equip")
 = game_player_equip:
 	"An entity that gives equipment to the player who activates it. " + 

--- a/fgd/point/game/game_player_team.fgd
+++ b/fgd/point/game/game_player_team.fgd
@@ -1,5 +1,5 @@
 @PointClass appliesto(+USE_TEAM)
-	base(BaseEntityPoint, MasterEnt)
+	base(BaseEntityPoint)
 	iconsprite("editor/ficool2/game_player_team")
 	color(200 0 0) 
 = game_player_team: "An entity that changes the team of the player who activates it."

--- a/fgd/point/game/game_score.fgd
+++ b/fgd/point/game/game_score.fgd
@@ -1,5 +1,5 @@
 @PointClass appliesto(+USE_MULTIPLAYER)
-	base(BaseEntityPoint, MasterEnt)
+	base(BaseEntityPoint)
 	iconsprite("editor/ficool2/game_score")
 	color(200 0 0)
 = game_score: "An entity that awards/deducts points from the player who activates it or to a specific team."

--- a/fgd/point/game/game_text.fgd
+++ b/fgd/point/game/game_text.fgd
@@ -1,4 +1,4 @@
-@PointClass base(BaseEntityPoint, MasterEnt)
+@PointClass base(BaseEntityPoint)
 	iconsprite("editor/game_text.vmt") 
 	color(200 0 0) 
 = game_text: "An entity that displays text on player's screens."

--- a/fgd/point/info/info_player_start.fgd
+++ b/fgd/point/info/info_player_start.fgd
@@ -3,10 +3,10 @@
 = info_player_start: "This entity indicates the position and facing direction at which the player will spawn. " +
 	"Any number of info_player_start entities may be placed in a map for when working in cordoned-off portions of the map. " +
 	"When multiple info_player_start entities are present in a map, " +
-	"set the 'Master' spawnflag on one of them to indicate which one should be used when running the entire map."
+	"set the 'Default Spawn Point' spawnflag on one of them to indicate which one should be used when running the entire map."
 	[
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Master (Has priority if multiple info_player_starts exist)" : 0
+		1: "Default Spawn Point" : 0
 		]
 	]

--- a/fgd/point/info/info_player_start.fgd
+++ b/fgd/point/info/info_player_start.fgd
@@ -3,10 +3,10 @@
 = info_player_start: "This entity indicates the position and facing direction at which the player will spawn. " +
 	"Any number of info_player_start entities may be placed in a map for when working in cordoned-off portions of the map. " +
 	"When multiple info_player_start entities are present in a map, " +
-	"set the 'Default Spawn Point' spawnflag on one of them to indicate which one should be used when running the entire map."
+	"set the 'Primary Spawn Point' spawnflag on one of them to indicate which one should be used when running the entire map."
 	[
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Default Spawn Point" : 0
+		1: "Primary Spawn Point" : 0
 		]
 	]

--- a/fgd/point/item/item_dynamic_resupply.fgd
+++ b/fgd/point/item/item_dynamic_resupply.fgd
@@ -10,17 +10,17 @@
 	"In that case, a random piece of ammo used by a weapon, that the player has, will be spawned. " +
 	"If the 'Fallback to Health Vial' spawnflag is set, a health vial will be spawned instead of the ammo." +
 	"\n\n" +
-	"By default, the item_dynamic_resupply uses the values inside the Master resupply, instead of using it's own values. " +
+	"By default, the item_dynamic_resupply uses the values inside the primary resupply, instead of using its own values. " +
 	"This makes it easy to tweak the desired loadout of many resupplies. " +
-	"The BecomeMaster input allows you to switch Masters dynamically as the level progresses."
+	"The BecomeMaster input allows you to switch primary resupplies dynamically as the level progresses."
 	[
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Use Master's values" : 1
-		2: "Is Master" : 0
+		1: "Use primary resupply values" : 1
+		2: "Is primary resupply entity" : 0
 		4: "Spawn even if player meets all requirements" : 0
-		8: "Fallback to Health Vial" : 0
-		16: "Alternate master" : 0
+		8: "Force-spawn health vial if player inventory is full" : 0
+		16: "Alternate resupply" : 0
 		]
 
 	desiredhealth(float) : "Desired Health Ratio" : 1 : "A ratio from 0 to 1." +
@@ -50,8 +50,8 @@
 
 	// Inputs
 	input CalculateType(void) : "Force the dynamic resupply to calculate which item it should spawn."
-	input BecomeMaster(void) : "Make this resupply the master resupply. " +
-		"All other resupplies set to Use Master's Values will now use this resupply's values."
+	input BecomeMaster(void) : "Make this dynamic resupply the primary resupply. " +
+		"All other resupplies set to use the primary resupply's parameters will now use the values specified by this entity instead."
 
 	// Outputs
 	output OnItem(ehandle) : "Fired with each item created by this box."

--- a/fgd/point/item/item_item_crate.fgd
+++ b/fgd/point/item/item_item_crate.fgd
@@ -18,7 +18,7 @@
 
 	itemclass(pointentityclass) : "Item Type" : "item_dynamic_resupply" : "Class name of the entity to spawn when the crate is broken"
 	itemcount(integer) : "Item Count" : 1 : "Number of items to emit upon breakage"
-	specificresupply(target_destination) : "Specific resupply" : : "If item type is item_dynamic_resupply, specify a specific one to use instead of the master"
+	specificresupply(target_destination) : "Specific resupply" : : "If item type is item_dynamic_resupply, specify a specific one to use instead of the primary resupply."
 
 	// Inputs
 	input Kill(void) : "Remove the item crate"

--- a/fgd/point/postprocess/postprocess_controller.fgd
+++ b/fgd/point/postprocess/postprocess_controller.fgd
@@ -4,27 +4,30 @@
 = postprocess_controller: "When present, enables post-processing effects from Left 4 Dead 2, which include film grain, contrast adjustment, depth-of-field and vignettes."
 	[
 	fadetime(float) : "Fade-in time" : "2"
-	localcontraststrength(float) : "Local contrast strength [-1..x]" : "0" : "Global contrast strength."
-	localcontrastedgestrength(float) : "Local contrast edge strength [0..1]" : "0" : "Contrast strength for edges displayed on-screen."
+	localcontraststrength(float) : "Local contrast strength [0-1]" : "0" : "Global contrast strength. Accepts negative values."
+	localcontrastedgestrength(float) : "Local contrast edge strength [0-1]" : "0" : "Contrast strength for edges displayed on-screen."
 
-	vignettestart(float) : "Vignette start distance [0..1]" : "0.8" : "The linear start point of the vignette effect."
+	vignettestart(float) : "Vignette start distance [0-1]" : "0.8" : "The linear start point of the vignette effect."
 	vignetteend(float) : "Vignette end distance [0..x]" : "1.1" : "The linear end point of the vignette effect."
 
-	// inverted in cstrike15
 	vignetteblurstrength(float) : "Vignette blur strength" : "1" : "How strong the vignette effect should be, from a range of 0 through 1." +
 	"Specifying blur strength values past 1 can invert the game's colors."
+	
+	// inverted in csgo and later
 	fadetoblackstrength(float) : "Fade to black strength" : "1" : "How strong the vignette effect should be, from a range of 0 through 1." +
 	"In CS:GO and later games, this value ranges from 1 through 0 as this parameter's output is inverted."
 
-	depthblurfocaldistance(float) : "Depth-blur focal plane distance [0..1]" : "0"
-	depthblurstrength(float) : "Depth-blur effect strength [0..x]" : "0"
-	screenblurstrength(float) : "Full-screen blur strength [0..1]" : "0"
-	filmgrainstrength(float) : "Film grain strength [0..x]" : "0" : "How strong the film grain effect should be, from a range of 0 through 1." +
+	depthblurfocaldistance(float) : "Depth-blur focal plane distance [0-1]" : "0"
+	depthblurstrength(float) : "Depth-blur effect strength [0-x]" : "0"
+	screenblurstrength(float) : "Full-screen blur strength [0-1]" : "0"
+
+	// inverted in csgo and later
+	filmgrainstrength(float) : "Film grain strength [1-0]" : "1" : "How strong the film grain effect should be, from a range of 0 through 1." +
 	"In CS:GO and later games, this value ranges from 1 through 0 as this parameter's output is inverted."
 
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Defaut Post-Process Controller" : 0
+		1: "Primary Post-Process Controller" : 0
 		]
 
 	// Inputs

--- a/fgd/point/postprocess/postprocess_controller.fgd
+++ b/fgd/point/postprocess/postprocess_controller.fgd
@@ -27,7 +27,7 @@
 
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Primary Post-Process Controller" : 0
+		1: "Primary Post-Process Controller (takes priority over existing controllers)" : 0
 		]
 
 	// Inputs

--- a/fgd/point/postprocess/postprocess_controller.fgd
+++ b/fgd/point/postprocess/postprocess_controller.fgd
@@ -1,26 +1,30 @@
 @PointClass base(BaseEntityPoint)
 	iconsprite("editor/postprocess_controller.vmt") 
 	color(255 255 255) 
-= postprocess_controller: "An entity that controls the postprocess settings in the map."
+= postprocess_controller: "When present, enables post-processing effects from Left 4 Dead 2, which include film grain, contrast adjustment, depth-of-field and vignettes."
 	[
 	fadetime(float) : "Fade-in time" : "2"
-	localcontraststrength(float) : "Local contrast strength [-1..x]" : "0"
-	localcontrastedgestrength(float) : "Local contrast edge strength [0..1]" : "0"
+	localcontraststrength(float) : "Local contrast strength [-1..x]" : "0" : "Global contrast strength."
+	localcontrastedgestrength(float) : "Local contrast edge strength [0..1]" : "0" : "Contrast strength for edges displayed on-screen."
 
-	vignettestart(float) : "Vignette start distance [0..1]" : "0.8"
-	vignetteend(float) : "Vignette end distance [0..x]" : "1.1"
+	vignettestart(float) : "Vignette start distance [0..1]" : "0.8" : "The linear start point of the vignette effect."
+	vignetteend(float) : "Vignette end distance [0..x]" : "1.1" : "The linear end point of the vignette effect."
 
-	vignetteblurstrength(float) : "Vignette blur strength [0..1]" : "0"
-	fadetoblackstrength(float) : "Fade to black strength [0..1]" : "0"
+	// inverted in cstrike15
+	vignetteblurstrength(float) : "Vignette blur strength" : "1" : "How strong the vignette effect should be, from a range of 0 through 1." +
+	"Specifying blur strength values past 1 can invert the game's colors."
+	fadetoblackstrength(float) : "Fade to black strength" : "1" : "How strong the vignette effect should be, from a range of 0 through 1." +
+	"In CS:GO and later games, this value ranges from 1 through 0 as this parameter's output is inverted."
 
 	depthblurfocaldistance(float) : "Depth-blur focal plane distance [0..1]" : "0"
 	depthblurstrength(float) : "Depth-blur effect strength [0..x]" : "0"
 	screenblurstrength(float) : "Full-screen blur strength [0..1]" : "0"
-	filmgrainstrength(float) : "Film grain strength [0..x]" : "0"
+	filmgrainstrength(float) : "Film grain strength [0..x]" : "0" : "How strong the film grain effect should be, from a range of 0 through 1." +
+	"In CS:GO and later games, this value ranges from 1 through 0 as this parameter's output is inverted."
 
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Master (Has priority if multiple postprocess_controllers exist)" : 0
+		1: "Defaut Post-Process Controller" : 0
 		]
 
 	// Inputs

--- a/fgd/point/prop/prop_door_rotating.fgd
+++ b/fgd/point/prop/prop_door_rotating.fgd
@@ -4,7 +4,8 @@
 	// line(255, 255, 255, targetname, slavename)
 = prop_door_rotating: "An entity used to place a door in the world."
 	[
-	slavename(target_destination) : "Slave Name" : : "The name of any doors that should be slaved to this door " +
+	// This param name really needs to be replaced in code!!
+	slavename(target_destination) : "Secondary Door Name" : : "The secondary door name(s) that should be tied/linked to this specific door " +
 		"(i.e. should open when this one opens, and close when this one closes)."
 
 	hardware[engine](integer) : "Hardware Type" : 1

--- a/fgd/point/sky/sky_camera.fgd
+++ b/fgd/point/sky/sky_camera.fgd
@@ -14,7 +14,7 @@
 
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Primary Sky Camera" : 0
+		1: "Primary Sky Camera (takes priority if multiple sky_cameras exist)" : 0
 		2: "Continuously update position (for moving sky_cameras)" : 0
 		]
 

--- a/fgd/point/sky/sky_camera.fgd
+++ b/fgd/point/sky/sky_camera.fgd
@@ -14,7 +14,7 @@
 
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Default Sky Camera" : 0
+		1: "Primary Sky Camera" : 0
 		2: "Continuously update position (for moving sky_cameras)" : 0
 		]
 

--- a/fgd/point/sky/sky_camera.fgd
+++ b/fgd/point/sky/sky_camera.fgd
@@ -14,7 +14,7 @@
 
 	spawnflags(flags) : "spawnflags" =
 		[
-		1: "Master (takes priority if multiple sky_cameras exist)" : 0
+		1: "Default Sky Camera" : 0
 		2: "Continuously update position (for moving sky_cameras)" : 0
 		]
 

--- a/fgd/point/team/team_control_point_master.fgd
+++ b/fgd/point/team/team_control_point_master.fgd
@@ -1,6 +1,6 @@
 @PointClass base(BaseEntityPoint, EnableDisable) 
 	appliesto(TF2_ENTITIES)
-= team_control_point_master: "Control Point Master"
+= team_control_point_master: "Team Fortress 2 control point manager. Defines how player control point assets are defined per-team and imposes restrictions on captures."
 	[
 	team_base_icon_2(material) : "Material for the RED Base icon" : "sprites/obj_icons/icon_base_red"
 	team_base_icon_3(material) : "Material for the BLUE Base icon" : "sprites/obj_icons/icon_base_blu"
@@ -42,10 +42,10 @@
 	input SetCapLayoutCustomPositionX(float) : "Set the cap layout custom X position [0,1]"
 	input SetCapLayoutCustomPositionY(float) : "Set the cap layout custom Y position [0,1]"
 
-	input RoundSpawn(void) : "Clear out old control points,round AND find the new control points,round and if successful, do CPMThink AND also tell  the resource to ResetControlPoints."
-	input RoundActivate(void) : "if we're using mini-rounds and haven't picked one yet, find one to play OR Tell the objective resource what control points are in use in the selected mini-round."
+	input RoundSpawn(void) : "Reset all control points to their default states."
+	input RoundActivate(void) : "Activate all control points for the current game's round or stage."
 
 	// Outputs
 	output OnWonByTeam1(void) : "Sent when RED wins the game."
-	output OnWonByTeam2(void) : "Sent when BLUE wins the game."
+	output OnWonByTeam2(void) : "Sent when BLU wins the game."
 	]

--- a/fgd/point/vgui/vgui_movie_display.fgd
+++ b/fgd/point/vgui/vgui_movie_display.fgd
@@ -41,18 +41,18 @@
 		"media/menu_act04.webm"				: "Menu Background: Act 4"
 		"media/menu_act05.webm"				: "Menu Background: Act 5"
 		"media/sp_30_a4_finale5.webm"		: "SP Ending"
-		"media/sp_credits_bg.webm"			: "Want You Gone Background"
+		"media/sp_credits_bg.webm"			: "SP Credits Background"
 		"media/sp_a5_credits.webm"			: "Space"
-		"media/sp_ending_callback.webm"		: "Space Wheatley"
+		"media/sp_ending_callback.webm"		: "Post-Credits Sequence"
 		
 		// Coop
 		"media/coop_bluebot_load.webm"		: "ATLAS Schematic"
-		"media/coop_orangebot_load.webm"		: "P-Body Schematic"
+		"media/coop_orangebot_load.webm"	: "P-Body Schematic"
 		"media/coop_bots_load.webm"			: "Conveyor Bots"
-		"media/coop_bots_load_wave.webm"		: "Waving Bots"
+		"media/coop_bots_load_wave.webm"	: "Waving Bots"
 		"media/coop_intro.webm"				: "Coop Intro"
 		"media/coop_outro.webm"				: "Coop Outro"
-		"media/coop_bts_blueprints.webm"		: "Coop Disc: Blueprints"
+		"media/coop_bts_blueprints.webm"	: "Coop Disc: Blueprints"
 		"media/coop_bts_powergrid_01.webm"	: "Coop Disc: Power Grid 1"
 		"media/coop_bts_powergrid_02.webm"	: "Coop Disc: Power Grid 2"
 		"media/coop_bts_radar_01.webm"		: "Coop Disc: Radar 1"
@@ -61,7 +61,7 @@
 		"media/coop_bts_security_02.webm"	: "Coop Disc: Security 2"
 		"media/coop_bts_radar.webm"			: "Coop Disc: Unused Radar"
 		"media/coop_bts_security.webm"		: "Coop Disc: Unused Security"
-		"media/insert_disc.webm"				: "Insert Disc"
+		"media/insert_disc.webm"			: "Insert Disc"
 		"media/dlc1_endmovie.webm"			: "Art Therapy Outro"
 		
 		// Other
@@ -74,13 +74,14 @@
 		"media/attract_panels.webm"			: "Extras: Panels"
 		"media/attract_turrets.webm"			: "Extras: Turrets"
 		]
-	groupname(string) : "Group Name"
-	looping(boolean) : "Loop Movie" : 0
+	groupname(string) : "Group Name" : "" : "Specify the group that this video panel belongs to. Any commands issued to the primary video panel in this group will cause all other panels to follow its behavior."
+	looping(boolean) : "Loop Movie" : 0 : "Should this video play in an infinite loop?"
 	
 	width(integer) : "Panel Width in World (Green)" : 256 : "Width of the panel in units."
 	height(integer) : "Panel Height in World (Blue)" : 128 : "Height of the panel in units."
 	stretch(boolean) : "Stretch to Fill" : 0
-	forcedslave(boolean) : "Forced slave" : 0
+	// Needs to be changed in code!!!
+	forcedslave(boolean) : "Linked panel" : 0 : "Inputs from the primary vgui_movie_display entity this is linked to should also be redirected to this entity."
 	forceprecache(boolean) : "Force precache" : 0 : "Precache the movie referred to by Movie Filename on entity spawn."
 
 	noscanline(boolean) : "Disable Scanline Overlay" : 0 : "Disables the default scanline overlay."
@@ -100,7 +101,7 @@
 	input SetDisplayText(string) : "Sets the display text."
 	input SetMovie(string) : "Sets the movie to display."
 	input SetUseCustomUVs(boolean) : "Use custom UVs."
-	input TakeOverAsMaster(void) : "Start using this video as the master of it's group."
+	input TakeOverAsMaster(void) : "Set this specific panel as the primary video display entity."
 	input SetUMin(float) : "Set the minimum U."
 	input SetUMax(float) : "Set the maximum U."
 	input SetVMin(float) : "Set the minimum V."


### PR DESCRIPTION
This PR removes virtually almost _all_ references to the "master"/"slave" terminology from the Strata FGDs, except for internal keyvalues parameters directly bound to by engine code.

The `MasterEnt` FGD (which was used by the HL1 `multisource` entity) has also been removed as it no longer exists in Strata engine code. Any entity that used to rely on this has had their FGDs modified to no longer reference it.