### PR TITLE
Remove rtt shadow references, add shadowdepth kv to BaseEntityPhysics

### DIFF
--- a/fgd/bases/BaseEntityAnimating.fgd
+++ b/fgd/bases/BaseEntityAnimating.fgd
@@ -59,8 +59,6 @@
 		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
 		"and greater than 1 cause it to fade out at closer distances."
 	
-	shadowcastdist(integer) : "Shadow Cast Distance" : : "Sets how far the entity casts dynamic shadows, in units. 0 means default distance from the shadow_control entity."
-	disableshadows(boolean) : "Disable Shadows?" : 0 : "Prevent the entity from creating cheap render-to-texture/dynamic shadows."
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
 	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."
 	shadowdepthnocache(choices) : "Projected Texture Cache" : "0" : "Used to hint projected texture system whether it is sufficient to cache shadow volume of this entity or to force render it every frame instead." =
@@ -88,8 +86,6 @@
 	input fademindist(float) : "Sets distance at which the entity starts fading. If <0, the entity will disappear instantly when end fade is hit. The value will scale appropriately if the entity is in a 3D Skybox."
 	input fademaxdist(float) : "Sets distance at which the entity ends fading. If <0, the entity won't disappear at all. The value will scale appropriately if the entity is in a 3D Skybox."
 	
-	input DisableShadow(void) : "Allows the entity to draw a render target (dynamic) shadow."
-	input EnableShadow(void) : "Prevents the entity from drawing a render target (dynamic) shadow."
 	input DisableReceivingFlashlight(void) : "This object will not recieve light or shadows from clustered lights."
 	input EnableReceivingFlashlight(void) : "This object will recieve light or shadows from clustered lights."
 	

--- a/fgd/bases/BaseEntityPhysics.fgd
+++ b/fgd/bases/BaseEntityPhysics.fgd
@@ -30,9 +30,8 @@
 		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
 		"and greater than 1 cause it to fade out at closer distances."
 
-	shadowcastdist(integer) : "Shadow Cast Distance" : : "Sets how far the entity casts dynamic shadows, in units. 0 means default distance from the shadow_control entity."
-	disableshadows(boolean) : "Disable Shadows?" : 0 : "Prevent the entity from creating cheap render-to-texture/dynamic shadows."
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
+	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."
 	modelscale(float) : "Model Scale" : : "A multiplier for the size of the model. Negative values are accepted. Does not alter the physics collisions in most cases, however. Negative values can crash the game!"
 
 	AllowSilentDissolve[+P2](boolean) : "Allow SilentDissolve input" : 1 : "Allow the SilentDissolve input to dissolve this object."
@@ -52,8 +51,9 @@
 	input SetLightingOriginHack(string) : "Offsets the entity's lighting origin by their distance from an info_lighting_relative."
 	input fademindist(float) : "Sets distance at which the entity starts fading. If <0, the entity will disappear instantly when end fade is hit. The value will scale appropriately if the entity is in a 3D Skybox."
 	input fademaxdist(float) : "Sets distance at which the entity ends fading. If <0, the entity won't disappear at all. The value will scale appropriately if the entity is in a 3D Skybox."
-	input DisableShadow(void) : "Allows the entity to draw a render target (dynamic) shadow."
-	input EnableShadow(void) : "Prevents the entity from drawing a render target (dynamic) shadow."
+	
+	input DisableReceivingFlashlight(void) : "This object will not recieve light or shadows from clustered lights."
+	input EnableReceivingFlashlight(void) : "This object will recieve light or shadows from clustered lights."
 
 	input Dissolve[+P2](void) : "Fizzles the object, firing the OnFizzled output."
 	input SilentDissolve[+P2](void) : "Kills the object immediately, firing the OnFizzled output."


### PR DESCRIPTION
This removes references to the now removed rtt shadow system, to prevent it from being confusing for mappers when the keyvalues don't function. It also adds the functional disableshadowdepth keyvalue to BaseEntityPhysics to act as a proper replacement.