### PR TITLE
Portal fix and glow keyvalues

### DIFF
--- a/fgd/bases/BaseEntityAnimating.fgd
+++ b/fgd/bases/BaseEntityAnimating.fgd
@@ -64,10 +64,10 @@
 	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
 	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
 		[
-		0: "Default (through walls)"
-		1: "Shimmer (doesn't glow through walls)"
-		2: "Outline (doesn't glow through walls)"
-		3: "Outline Pulse (doesn't glow through walls)"
+		0: "Outline (glows through walls)"
+		1: "Full Glow (doesn't glow through walls)"
+		2: "Wireframe (doesn't glow through walls)"
+		3: "Wireframe Pulse (doesn't glow through walls)"
 		]
 	
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."

--- a/fgd/bases/BaseEntityAnimating.fgd
+++ b/fgd/bases/BaseEntityAnimating.fgd
@@ -1,5 +1,5 @@
 // All model entities have this.
-@BaseClass base(BaseEntityPoint, RenderFields, Reflection, ToggleDraw, DamageFilter) 
+@BaseClass base(BaseEntityPoint, RenderFields, Glow, Reflection, ToggleDraw, DamageFilter) 
 	sphere(fademindist) sphere(fademaxdist)
 = BaseEntityAnimating
 	[
@@ -59,17 +59,6 @@
 		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
 		"and greater than 1 cause it to fade out at closer distances."
 	
-	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect allows the player to see important props more easily."
-	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow outline (if enabled)."
-	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
-	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
-		[
-		0: "Outline (glows through walls)"
-		1: "Full Glow (doesn't glow through walls)"
-		2: "Wireframe (doesn't glow through walls)"
-		3: "Wireframe Pulse (doesn't glow through walls)"
-		]
-	
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
 	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."
 	shadowdepthnocache(choices) : "Projected Texture Cache" : "0" : "Used to hint projected texture system whether it is sufficient to cache shadow volume of this entity or to force render it every frame instead." =
@@ -96,13 +85,6 @@
 	input SetLightingOriginHack(string) : "Offsets the entity's lighting origin by their distance from an info_lighting_relative."
 	input fademindist(float) : "Sets distance at which the entity starts fading. If <0, the entity will disappear instantly when end fade is hit. The value will scale appropriately if the entity is in a 3D Skybox."
 	input fademaxdist(float) : "Sets distance at which the entity ends fading. If <0, the entity won't disappear at all. The value will scale appropriately if the entity is in a 3D Skybox."
-	
-	input SetGlowEnabled(void) : "Enable a glow outline around this model."
-	input SetGlowColor(color255) : "Sets the RGB color of the glow outline, if enabled."
-	input SetGlowDisabled(void) : "Disable the glow outline."
-	input GlowColorRedValue(float) : "Sets the glow red color channel's value (0 - 255)."
-	input GlowColorGreenValue(float) : "Sets the glow green color channel's value (0 - 255)."
-	input GlowColorBlueValue(float) : "Sets the glow blue color channel's value (0 - 255)."
 	
 	input DisableReceivingFlashlight(void) : "This object will not recieve light or shadows from clustered lights."
 	input EnableReceivingFlashlight(void) : "This object will recieve light or shadows from clustered lights."

--- a/fgd/bases/BaseEntityAnimating.fgd
+++ b/fgd/bases/BaseEntityAnimating.fgd
@@ -59,6 +59,10 @@
 		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
 		"and greater than 1 cause it to fade out at closer distances."
 	
+	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect is visible through walls and allows the player to see important props more easily."
+	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow outline (if enabled)."
+	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
+	
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
 	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."
 	shadowdepthnocache(choices) : "Projected Texture Cache" : "0" : "Used to hint projected texture system whether it is sufficient to cache shadow volume of this entity or to force render it every frame instead." =
@@ -85,6 +89,13 @@
 	input SetLightingOriginHack(string) : "Offsets the entity's lighting origin by their distance from an info_lighting_relative."
 	input fademindist(float) : "Sets distance at which the entity starts fading. If <0, the entity will disappear instantly when end fade is hit. The value will scale appropriately if the entity is in a 3D Skybox."
 	input fademaxdist(float) : "Sets distance at which the entity ends fading. If <0, the entity won't disappear at all. The value will scale appropriately if the entity is in a 3D Skybox."
+	
+	input SetGlowEnabled(void) : "Enable a glow outline around this model."
+	input SetGlowColor(color255) : "Sets the RGB color of the glow outline, if enabled."
+	input SetGlowDisabled(void) : "Disable the glow outline."
+	input GlowColorRedValue(float) : "Sets the glow red color channel's value (0 - 255)."
+	input GlowColorGreenValue(float) : "Sets the glow green color channel's value (0 - 255)."
+	input GlowColorBlueValue(float) : "Sets the glow blue color channel's value (0 - 255)."
 	
 	input DisableReceivingFlashlight(void) : "This object will not recieve light or shadows from clustered lights."
 	input EnableReceivingFlashlight(void) : "This object will recieve light or shadows from clustered lights."

--- a/fgd/bases/BaseEntityAnimating.fgd
+++ b/fgd/bases/BaseEntityAnimating.fgd
@@ -59,7 +59,7 @@
 		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
 		"and greater than 1 cause it to fade out at closer distances."
 	
-	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect is visible through walls and allows the player to see important props more easily."
+	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect allows the player to see important props more easily."
 	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow outline (if enabled)."
 	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
 	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =

--- a/fgd/bases/BaseEntityAnimating.fgd
+++ b/fgd/bases/BaseEntityAnimating.fgd
@@ -62,6 +62,13 @@
 	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect is visible through walls and allows the player to see important props more easily."
 	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow outline (if enabled)."
 	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
+	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
+		[
+		0: "Default (through walls)"
+		1: "Shimmer (doesn't glow through walls)"
+		2: "Outline (doesn't glow through walls)"
+		3: "Outline Pulse (doesn't glow through walls)"
+		]
 	
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
 	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."

--- a/fgd/bases/BaseEntityPhysics.fgd
+++ b/fgd/bases/BaseEntityPhysics.fgd
@@ -30,6 +30,10 @@
 		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
 		"and greater than 1 cause it to fade out at closer distances."
 
+	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect is visible through walls and allows the player to see important props more easily."
+	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow outline (if enabled)."
+	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
+
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
 	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."
 	modelscale(float) : "Model Scale" : : "A multiplier for the size of the model. Negative values are accepted. Does not alter the physics collisions in most cases, however. Negative values can crash the game!"
@@ -51,6 +55,13 @@
 	input SetLightingOriginHack(string) : "Offsets the entity's lighting origin by their distance from an info_lighting_relative."
 	input fademindist(float) : "Sets distance at which the entity starts fading. If <0, the entity will disappear instantly when end fade is hit. The value will scale appropriately if the entity is in a 3D Skybox."
 	input fademaxdist(float) : "Sets distance at which the entity ends fading. If <0, the entity won't disappear at all. The value will scale appropriately if the entity is in a 3D Skybox."
+	
+	input SetGlowEnabled(void) : "Enable a glow outline around this model."
+	input SetGlowColor(color255) : "Sets the RGB color of the glow outline, if enabled."
+	input SetGlowDisabled(void) : "Disable the glow outline."
+	input GlowColorRedValue(float) : "Sets the glow red color channel's value (0 - 255)."
+	input GlowColorGreenValue(float) : "Sets the glow green color channel's value (0 - 255)."
+	input GlowColorBlueValue(float) : "Sets the glow blue color channel's value (0 - 255)."
 	
 	input DisableReceivingFlashlight(void) : "This object will not recieve light or shadows from clustered lights."
 	input EnableReceivingFlashlight(void) : "This object will recieve light or shadows from clustered lights."

--- a/fgd/bases/BaseEntityPhysics.fgd
+++ b/fgd/bases/BaseEntityPhysics.fgd
@@ -30,7 +30,7 @@
 		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
 		"and greater than 1 cause it to fade out at closer distances."
 
-	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect is visible through walls and allows the player to see important props more easily."
+	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect allows the player to see important props more easily."
 	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow outline (if enabled)."
 	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
 	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =

--- a/fgd/bases/BaseEntityPhysics.fgd
+++ b/fgd/bases/BaseEntityPhysics.fgd
@@ -33,6 +33,13 @@
 	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect is visible through walls and allows the player to see important props more easily."
 	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow outline (if enabled)."
 	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
+	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
+		[
+		0: "Default (through walls)"
+		1: "Shimmer (doesn't glow through walls)"
+		2: "Outline (doesn't glow through walls)"
+		3: "Outline Pulse (doesn't glow through walls)"
+		]
 
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
 	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."

--- a/fgd/bases/BaseEntityPhysics.fgd
+++ b/fgd/bases/BaseEntityPhysics.fgd
@@ -35,10 +35,10 @@
 	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
 	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
 		[
-		0: "Default (through walls)"
-		1: "Shimmer (doesn't glow through walls)"
-		2: "Outline (doesn't glow through walls)"
-		3: "Outline Pulse (doesn't glow through walls)"
+		0: "Outline (glows through walls)"
+		1: "Full Glow (doesn't glow through walls)"
+		2: "Wireframe (doesn't glow through walls)"
+		3: "Wireframe Pulse (doesn't glow through walls)"
 		]
 
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."

--- a/fgd/bases/BaseEntityPhysics.fgd
+++ b/fgd/bases/BaseEntityPhysics.fgd
@@ -1,6 +1,6 @@
 // Stripped down version of BaseAnimating for physically-simulated objects, which do not have some keyvalues
 
-@BaseClass base(BaseEntityPoint, RenderFields, Reflection, DamageFilter) 
+@BaseClass base(BaseEntityPoint, RenderFields, Glow, Reflection, DamageFilter) 
 	sphere(fademindist) sphere(fademaxdist)
 = BaseEntityPhysics
 	[
@@ -30,17 +30,6 @@
 		"Numbers smaller than 1 cause the prop to fade out at further distances, " +
 		"and greater than 1 cause it to fade out at closer distances."
 
-	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow outline around this prop. This effect allows the player to see important props more easily."
-	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow outline (if enabled)."
-	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow outline fades out."
-	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
-		[
-		0: "Outline (glows through walls)"
-		1: "Full Glow (doesn't glow through walls)"
-		2: "Wireframe (doesn't glow through walls)"
-		3: "Wireframe Pulse (doesn't glow through walls)"
-		]
-
 	disablereceiveshadows(boolean) : "Disable Receiving Shadows?" : 0 : "Prevents dynamic shadows (e.g. player and prop shadows) from appearing on this entity."
 	disableshadowdepth(boolean) : "Disable ShadowDepth" : 0 : "Used to disable rendering into shadow depth (for clustered lights) for this entity."
 	modelscale(float) : "Model Scale" : : "A multiplier for the size of the model. Negative values are accepted. Does not alter the physics collisions in most cases, however. Negative values can crash the game!"
@@ -62,13 +51,6 @@
 	input SetLightingOriginHack(string) : "Offsets the entity's lighting origin by their distance from an info_lighting_relative."
 	input fademindist(float) : "Sets distance at which the entity starts fading. If <0, the entity will disappear instantly when end fade is hit. The value will scale appropriately if the entity is in a 3D Skybox."
 	input fademaxdist(float) : "Sets distance at which the entity ends fading. If <0, the entity won't disappear at all. The value will scale appropriately if the entity is in a 3D Skybox."
-	
-	input SetGlowEnabled(void) : "Enable a glow outline around this model."
-	input SetGlowColor(color255) : "Sets the RGB color of the glow outline, if enabled."
-	input SetGlowDisabled(void) : "Disable the glow outline."
-	input GlowColorRedValue(float) : "Sets the glow red color channel's value (0 - 255)."
-	input GlowColorGreenValue(float) : "Sets the glow green color channel's value (0 - 255)."
-	input GlowColorBlueValue(float) : "Sets the glow blue color channel's value (0 - 255)."
 	
 	input DisableReceivingFlashlight(void) : "This object will not recieve light or shadows from clustered lights."
 	input EnableReceivingFlashlight(void) : "This object will recieve light or shadows from clustered lights."

--- a/fgd/bases/Glow.fgd
+++ b/fgd/bases/Glow.fgd
@@ -1,0 +1,21 @@
+@BaseClass = Glow
+	[
+	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow effect around this prop. This effect allows the player to see important props more easily."
+	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow (if enabled)."
+	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow fades out."
+	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
+		[
+		0: "Outline (glows through walls)"
+		1: "Full Glow (doesn't glow through walls)"
+		2: "Wireframe (doesn't glow through walls)"
+		3: "Wireframe Pulse (doesn't glow through walls)"
+		]
+
+	// Inputs
+	input SetGlowEnabled(void) : "Enable a glow effect around this model."
+	input SetGlowDisabled(void) : "Disable the glow effect."
+	input SetGlowColor(color255) : "Sets the RGB color of the glow outline, if enabled."
+	input GlowColorRedValue(float) : "Sets the glow red color channel's value (0 - 255)."
+	input GlowColorGreenValue(float) : "Sets the glow green color channel's value (0 - 255)."
+	input GlowColorBlueValue(float) : "Sets the glow blue color channel's value (0 - 255)."
+	]

--- a/fgd/bases/Glow.fgd
+++ b/fgd/bases/Glow.fgd
@@ -3,6 +3,7 @@
 	glowenabled(boolean) : "Enable Glow" : 0 : "Enable a glow effect around this prop. This effect allows the player to see important props more easily."
 	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow (if enabled)."
 	glowdist(integer) : "Glow Distance" : 1024 : "The max distance before the glow fades out."
+	glowstyle[engine](integer) : "Glow Style" : 0
 	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
 		[
 		0: "Outline (glows through walls)"

--- a/fgd/point/prop/prop_door_rotating.fgd
+++ b/fgd/point/prop/prop_door_rotating.fgd
@@ -68,10 +68,6 @@
 		2: "Open Counter-Clockwise Only"
 		]
 
-	glowdist(integer) : "Glow Distance" : 1024
-	glowenabled(boolean) : "Does the prop glow by default?" : 0
-	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow (if enabled)."
-
 	// Inputs
 	input Open(void) : "Open the door, if it is not fully open."
 	input OpenAwayFrom(string) : "Open the door away from the specified entity."
@@ -83,8 +79,6 @@
 	input SetSpeed(float) : "Set the speed at which the door rotates. 100 is default."
 	
 	input MoveToRotationDistance(float) : "Sets the open distance (in degrees) and moves there."
-	input SetGlowEnabled(void) : "Starts the glow."
-	input SetGlowDisabled(void) : "Stops the glow."
 	input SetUnbreakable(void) : "The door can't be broken."
 	input SetBreakable(void) : "The door can be broken."
 

--- a/fgd/point/prop/prop_dynamic_glow.fgd
+++ b/fgd/point/prop/prop_dynamic_glow.fgd
@@ -2,14 +2,4 @@
 = prop_dynamic_glow: "A prop that can be placed in hierarchy and can play animations. It can also be configured to break when it takes enough damage.\nWorks exactly like a prop_dynamic, but it can optionally have a custom glow around it."
 	[
 	glowenabled(boolean) : "Does the prop glow by default?" : 1
-
-	glowstyle[engine](integer) : "Glow Style" : 0
-	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
-		[
-		0: "Default (through walls)"
-		1: "Shimmer (doesn't glow through walls)"
-		2: "Outline (doesn't glow through walls)"
-		3: "Outline Pulse (doesn't glow through walls)"
-		]
-
 	]

--- a/fgd/point/prop/prop_dynamic_glow.fgd
+++ b/fgd/point/prop/prop_dynamic_glow.fgd
@@ -1,9 +1,7 @@
 @PointClass base(prop_dynamic)
 = prop_dynamic_glow: "A prop that can be placed in hierarchy and can play animations. It can also be configured to break when it takes enough damage.\nWorks exactly like a prop_dynamic, but it can optionally have a custom glow around it."
 	[
-	glowdist(integer) : "Glow Distance" : 1024
 	glowenabled(boolean) : "Does the prop glow by default?" : 1
-	glowcolor(color255) : "Glow Color (R G B)" : "255 255 255" : "The color of the glow (if enabled)."
 
 	glowstyle[engine](integer) : "Glow Style" : 0
 	glowstyle(choices) : "Glow Style" : 0 : "What style of glow should be used." =
@@ -14,12 +12,4 @@
 		3: "Outline Pulse (doesn't glow through walls)"
 		]
 
-
-	// Inputs
-	input SetGlowEnabled(void) : "Starts the glow."
-	input SetGlowDisabled(void) : "Stops the glow."
-	input SetGlowColor(color255) : "Change the glow's color. Format: <Red 0-255> <Green 0-255> <Blue 0-255>"
-	input GlowColorRedValue(float) : "Sets the glow red color channel's value (0 - 255)."
-	input GlowColorGreenValue(float) : "Sets the glow green color channel's value (0 - 255)."
-	input GlowColorBlueValue(float) : "Sets the glow blue color channel's value (0 - 255)."
 	]

--- a/fgd/point/prop/prop_portal.fgd
+++ b/fgd/point/prop/prop_portal.fgd
@@ -1,7 +1,6 @@
 @PointClass base(BaseEntityPoint, PortalBase) 
 	appliesto(P2CE) 
 	studioprop("models/editor/prop_portal.mdl") 
-	size(-32 -16 -64, 32 16 64) 
 = prop_portal: "A portal."
 	[
 	activated[engine](boolean) : "Start Activated" : 0


### PR DESCRIPTION
This PR fixes an issue of a bounding box enveloping prop_portal inherited from https://github.com/StrataSource/FGD/pull/308, while also adding keyvalues and i/o for the hidden glow mechanic BaseEntityAnimating and BaseEntityPhysics have. Both of these have been tested on my end in the latest staging branch, and seem to be functional.