### PR TITLE
Add colors for disabled/inactive Qt widgets

### DIFF
--- a/hammer/resource/themes/dark.kv
+++ b/hammer/resource/themes/dark.kv
@@ -25,5 +25,29 @@
 		//"Link"  				""
 		//"LinkVisited" 		""
 		//"Shadow" 				""
+
+		"disabled"
+		{
+			"Text"  				"102 102 102"
+			"BrightText"  			"128 0 0"
+			"Button"  				"20 20 20"
+			"ButtonText"  			"96 96 96"
+
+			"Highlight"  			"219 65 65"
+			"HighlightedText" 		"10 10 10"
+		}
+		"inactive"
+		{
+			"Button"			"38 38 38"
+			"Text"  			"204 204 204"
+			"BrightText"  		"192 0 0"
+			"ButtonText"		"204 204 204"
+			"Base" 				"15 15 15"
+			"Window"  			"25 25 25"
+			"Highlight" 		"128 38 38"
+			"HighlightedText" 	"5 5 5"
+			"AlternateBase" 	"25 25 25"
+		}
 	}
 }
+


### PR DESCRIPTION
Adds colours for the disabled/inactive states of Qt widgets. This is mainly useful for Hammer. Not too attached to the specific colours, mostly just picked something so you can actually see if a widget is disabled.