### PR TITLE
Add various ways to configure portalgun travel delay

### DIFF
--- a/fgd/point/info/info_portal_gamerules.fgd
+++ b/fgd/point/info/info_portal_gamerules.fgd
@@ -13,6 +13,16 @@
 		3: "Dual Portal Device"
 		4: "Dual Portal Device (PotatOS attached)"
 		]
+
+	portalguntravelmode[engine](integer): "Travel Mode" : 0
+	portalguntravelmode(choices) : "Portal Gun Travel Mode" : 0 : "Determines whether shots take time to land like in Portal 1, or are instant like in Portal 2. \n" +
+		"If 'auto', this is determined automatically based on the BSP version." = 
+	[
+		0 : "Auto"
+		1 : "Projectile"
+		2 : "Instant"
+	]
+
 	equippaintgun(choices) : "Equip Paint Gun" : 0 : "Automatically grants the player a paint gun if enabled.\n\nThe \"basic paint gun\" option will give the player a paint gun with no powers assigned by default - paint powers must be obtained by touching an item_paint_power_pickup entity. Selecting the \"Fully-upgraded paint gun\" option will give the player all applicable paint powers for the paint gun." =
 		[
 		0: "None"

--- a/fgd/point/logic/logic_playerproxy.fgd
+++ b/fgd/point/logic/logic_playerproxy.fgd
@@ -25,6 +25,7 @@
 	input GivePortalGunPrimary[P2CE](void) : "Gives the player a portal gun with primary color. (Overrides if player is already holding one)"
 	input GivePortalGunSecondary[P2CE](void) : "Gives the player a portal gun with only secondary color. (Overrides if player is already holding one)"
 	input GivePortalGunNone[P2CE](void) : "Gives the player a portal gun with no activated colors. (Overrides if player is already holding one)"
+	input SetPortalGunTravelMode[P2CE](string) : "Set the player's portalgun travel mode. Valid parameters: auto, slow/projectile, fast/instant."
 	input GiveBoots[P2CE](void) : "Gives the player long fall boots."
 	input RemoveBoots[P2CE](void) : "Removes long fall boots from the player, if they have them."
 	input GivePaintGunFull[P2CE](void) : "Gives the player a fully upgraded paint gun."
@@ -34,7 +35,7 @@
 	input LowerWeapon[P2CE](void) : "Lowers the weapon, setting it to a disabled state."
 	input ReadyWeapon[P2CE](void) : "Raises the weapon, setting it to the default enabled state."
 	input SetFallDamageEnabled(boolean) : "Whether or not fall damage is enabled"
-	
+
 	// Outputs
 	output PlayerHealth[+HL2_ENTITIES, -P2CE](integer) : "The player's current health value, fired in response to RequestPlayerHealth. (Episodic only)"
 	output PlayerHasAmmo[+HL2_ENTITIES, -P2CE](void)   : "Fired by request if the player has any ammo. (Episodic only)"
@@ -42,7 +43,7 @@
 	output OnFlashlightOn[+HL2_ENTITIES, -P2CE](float) : "Fired when the player turns on their flashlight. This output has the value of how much energy the player had when this happened [0..1]. (Episodic only)"
 	output OnFlashlightOff[+HL2_ENTITIES, -P2CE](float) : "Fired when the player turns off their flashlight. This output has the value of how much energy the player had when this happened [0..1]. (Episodic only)"
 	output PlayerMissedAR2AltFire[+HL2_ENTITIES, -P2CE](void)	: "Player fired an AR2 combine ball that didn't kill any enemies. (Episodic only)"
-	
+
 	output PlayerDied(void) : "Fires when the player dies."
 	output OnStartSlowingTime(void) : "Fired when a Portal player initiates slow time."
 	output OnStopSlowingTime(void) : "Fired when a Portal player stops slowing time."

--- a/fgd/point/weapon/weapon_portalgun.fgd
+++ b/fgd/point/weapon/weapon_portalgun.fgd
@@ -38,6 +38,15 @@
 	Portal1Color(color255) : "Primary Portal Color" : "64 160 255" : "Color to use for the primary (Left/Blue) portal."
 	Portal2Color(color255) : "Secondary Portal Color" : "255 160 32" : "Color to use for the primary (Right/Orange) portal."
 
+	TravelMode[engine](integer): "Travel Mode" : 0
+	TravelMode(choices) : "Travel Mode" : 0 : "Determines whether shots take time to land like in Portal 1, or are instant like in Portal 2. \n" +
+		"If 'auto', this is determined automatically based on the BSP version." = 
+	[
+		0 : "Auto"
+		1 : "Projectile"
+		2 : "Instant"
+	]
+
 	// Inputs
 	input ChargePortal1(void) : "Does charge up effect for mounted portalgun. Missing particles and sounds."
 	input ChargePortal2(void) : "Does charge up effect for mounted portalgun. Missing particles and sounds."
@@ -45,6 +54,7 @@
 	input FirePortal2(void) : "Projects the 'orange' portal onto a wall in the facing direction of the gun."
 	input FirePortalDirection1(vector) : "Fires the 'blue' portal in the specified direction."
 	input FirePortalDirection2(vector) : "Fires the 'orange' portal in the specified direction."
+	input SetTravelMode(string) : "Set the portalgun's travel mode. Valid parameters: auto, slow/projectile, fast/instant."
 
 	// Outputs
 	output OnFiredPortal1(void) : "Fires when the 'blue' portal is fired."


### PR DESCRIPTION
Makes portalgun travel delay configurable via the portalgun itself, `info_portal_gamerules` and `logic_playerproxy`.