### PR TITLE
fix: Use correct sound for trigger_portal_cleanser disabling

### DIFF
--- a/fgd/brush/trigger/trigger_portal_cleanser.fgd
+++ b/fgd/brush/trigger/trigger_portal_cleanser.fgd
@@ -22,7 +22,7 @@
 	obstructportals(boolean) : "Obstruct Portals" : 1 : "Whether the fizzler will act like a portal bumper, and fizzle portals when enabled."
 	loopsound(sound) : "Looping Sound" : "VFX.FizzlerLp" : "Sound played continuously while the fizzler is active."
 	startsound(sound) : "Start Sound" : "VFX.FizzlerStart" : "Sound played when the fizzler turns on."
-	stopsound(sound) : "Stop Sound" : "VFX.FizzlerStop" : "Sound played when the fizzler turns off."
+	stopsound(sound) : "Stop Sound" : "VFX.FizzlerDestroy" : "Sound played when the fizzler turns off."
 
 	// Inputs
 	input FizzleTouchingPortals(void) : "Cause any portals in our volume to immediately fizzle."


### PR DESCRIPTION
This sound is a misnomer, it's actually called `Destroy`. The default in-code is correct.